### PR TITLE
fix: skill功能修复与增强

### DIFF
--- a/cmd/upload_skill.go
+++ b/cmd/upload_skill.go
@@ -46,6 +46,13 @@ var uploadSkillCmd = &cobra.Command{
 }
 
 func uploadSingleSkill(skillPath string, skillService *skill.SkillService) {
+	// Expand ~ to home directory
+	if strings.HasPrefix(skillPath, "~") {
+		homeDir, err := os.UserHomeDir()
+		checkError(err)
+		skillPath = filepath.Join(homeDir, skillPath[1:])
+	}
+
 	// Expand path
 	absPath, err := filepath.Abs(skillPath)
 	checkError(err)
@@ -61,6 +68,13 @@ func uploadSingleSkill(skillPath string, skillService *skill.SkillService) {
 }
 
 func uploadAllSkills(folderPath string, skillService *skill.SkillService) {
+	// Expand ~ to home directory
+	if strings.HasPrefix(folderPath, "~") {
+		homeDir, err := os.UserHomeDir()
+		checkError(err)
+		folderPath = filepath.Join(homeDir, folderPath[1:])
+	}
+
 	// List subdirectories
 	entries, err := os.ReadDir(folderPath)
 	checkError(err)

--- a/internal/client/nacos_client.go
+++ b/internal/client/nacos_client.go
@@ -103,12 +103,14 @@ func (c *NacosClient) login() error {
 	form := map[string]string{"username": c.Username, "password": c.Password}
 	isLocal := c.isLocalAddr()
 
+	// Try v3 first if not already determined to use v1
 	tryV3 := c.authLoginVersion == "" || c.authLoginVersion == "v3"
 	if tryV3 {
 		u := fmt.Sprintf("http://%s/nacos/v3/auth/user/login", c.ServerAddr)
 		resp, err := c.httpClient.R().SetFormData(form).Post(u)
 		if resp != nil && resp.StatusCode() == 200 && c.applyLoginResponse(resp.Body()) {
 			c.authLoginVersion = "v3"
+			return nil // v3 succeeded, no need to try v1
 		} else if !isLocal {
 			if err != nil {
 				fmt.Printf("v3 login failed: %v\n", err)
@@ -118,10 +120,12 @@ func (c *NacosClient) login() error {
 		}
 	}
 
+	// Fall back to v1 only if v3 failed or we're already using v1
 	u := fmt.Sprintf("http://%s/nacos/v1/auth/login", c.ServerAddr)
 	resp, err := c.httpClient.R().SetFormData(form).Post(u)
 	if resp != nil && resp.StatusCode() == 200 && c.applyLoginResponse(resp.Body()) {
 		c.authLoginVersion = "v1"
+		return nil
 	} else if !isLocal {
 		if err != nil {
 			fmt.Printf("v1 login failed: %v\n", err)

--- a/internal/skill/skill_service.go
+++ b/internal/skill/skill_service.go
@@ -296,6 +296,11 @@ func (s *SkillService) UploadSkill(skillPath string) error {
 	}
 
 	req.Header.Set("Content-Type", writer.FormDataContentType())
+	
+	// Add authentication header
+	if s.client.AccessToken != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", s.client.AccessToken))
+	}
 
 	client := &http.Client{}
 	resp, err := client.Do(req)


### PR DESCRIPTION
- 修复v3登录成功后仍尝试v1导致版本号被覆盖的bug
- 修复skill上传缺少认证Token的问题
- 支持skill-upload使用~路径(如 ~/skills/my-skill)