### PR TITLE
fix: skill-upload认证失败及 ~ 路径支持

### DIFF
--- a/cmd/upload_skill.go
+++ b/cmd/upload_skill.go
@@ -46,6 +46,13 @@ var uploadSkillCmd = &cobra.Command{
 }
 
 func uploadSingleSkill(skillPath string, skillService *skill.SkillService) {
+	// Expand ~ to home directory
+	if strings.HasPrefix(skillPath, "~") {
+		homeDir, err := os.UserHomeDir()
+		checkError(err)
+		skillPath = filepath.Join(homeDir, skillPath[1:])
+	}
+
 	// Expand path
 	absPath, err := filepath.Abs(skillPath)
 	checkError(err)
@@ -61,6 +68,13 @@ func uploadSingleSkill(skillPath string, skillService *skill.SkillService) {
 }
 
 func uploadAllSkills(folderPath string, skillService *skill.SkillService) {
+	// Expand ~ to home directory
+	if strings.HasPrefix(folderPath, "~") {
+		homeDir, err := os.UserHomeDir()
+		checkError(err)
+		folderPath = filepath.Join(homeDir, folderPath[1:])
+	}
+
 	// List subdirectories
 	entries, err := os.ReadDir(folderPath)
 	checkError(err)

--- a/internal/skill/skill_service.go
+++ b/internal/skill/skill_service.go
@@ -297,6 +297,11 @@ func (s *SkillService) UploadSkill(skillPath string) error {
 
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 
+	// Add authentication header
+	if s.client.AccessToken != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", s.client.AccessToken))
+	}
+
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {


### PR DESCRIPTION
- 添加Authorization header解决上传403错误
- 支持~路径(如 ~/skills/my-skill)