### PR TITLE
feat: migrate to v3 API and add tilde path support, update version to 0.0.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ BINARY_NAME=nacos-cli
 BUILD_DIR=build
 
 # Version
-VERSION?=0.0.7
+VERSION?=0.0.8
 
 # Go parameters
 GOCMD=go

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -7,7 +7,7 @@ const os = require('os');
 
 // Fixed nacos-cli binary version
 // npm package version is independent from binary version
-const VERSION = '0.0.5';
+const VERSION = '0.0.8';
 
 // Detect platform and architecture
 function getBinaryName() {

--- a/cmd/get_skill.go
+++ b/cmd/get_skill.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/nov11/nacos-cli/internal/client"
 	"github.com/nov11/nacos-cli/internal/help"
@@ -28,6 +29,17 @@ var getSkillCmd = &cobra.Command{
 			homeDir, err := os.UserHomeDir()
 			checkError(err)
 			getSkillOutput = filepath.Join(homeDir, ".skills")
+		} else {
+			// Expand ~ to home directory
+			if strings.HasPrefix(getSkillOutput, "~/") {
+				homeDir, err := os.UserHomeDir()
+				checkError(err)
+				getSkillOutput = filepath.Join(homeDir, getSkillOutput[2:])
+			} else if getSkillOutput == "~" {
+				homeDir, err := os.UserHomeDir()
+				checkError(err)
+				getSkillOutput = homeDir
+			}
 		}
 
 		// Create Nacos client

--- a/cmd/sync_skill.go
+++ b/cmd/sync_skill.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
+	"strings"
 	"syscall"
 
 	"github.com/nov11/nacos-cli/internal/client"
@@ -57,6 +59,19 @@ var syncSkillCmd = &cobra.Command{
 			os.Exit(1)
 		} else {
 			skillNames = args
+		}
+
+		// Expand ~ to home directory in syncOutputDir
+		if syncOutputDir != "" {
+			if strings.HasPrefix(syncOutputDir, "~/") {
+				homeDir, err := os.UserHomeDir()
+				checkError(err)
+				syncOutputDir = filepath.Join(homeDir, syncOutputDir[2:])
+			} else if syncOutputDir == "~" {
+				homeDir, err := os.UserHomeDir()
+				checkError(err)
+				syncOutputDir = homeDir
+			}
 		}
 
 		// Create Nacos client

--- a/internal/client/nacos_client.go
+++ b/internal/client/nacos_client.go
@@ -331,25 +331,29 @@ func (c *NacosClient) listConfigsV1(dataID, groupName, namespace string, pageNo,
 	return &configList, nil
 }
 
-// GetConfig retrieves a specific configuration
+// GetConfig retrieves a specific configuration using v3 client API
 func (c *NacosClient) GetConfig(dataID, group string) (string, error) {
 	if err := c.ensureTokenValid(); err != nil {
 		return "", err
 	}
+
+	ns := c.Namespace
+	if ns == "public" {
+		ns = ""
+	}
+
 	params := url.Values{}
 	params.Set("dataId", dataID)
-	params.Set("group", group)
-
-	if c.Namespace != "" {
-		params.Set("tenant", c.Namespace)
+	params.Set("groupName", group)
+	if ns != "" {
+		params.Set("namespaceId", ns)
 	}
 
-	if c.AuthType == AuthTypeNacos && c.AccessToken != "" {
-		params.Set("accessToken", c.AccessToken)
-	}
-
-	apiURL := fmt.Sprintf("http://%s/nacos/v1/cs/configs", c.ServerAddr)
+	apiURL := fmt.Sprintf("http://%s/nacos/v3/client/cs/config", c.ServerAddr)
 	req := c.httpClient.R().SetQueryString(params.Encode())
+	if c.AuthType == AuthTypeNacos && c.AccessToken != "" {
+		req.SetHeader("Authorization", fmt.Sprintf("Bearer %s", c.AccessToken))
+	}
 	c.setSpasHeaders(req, c.Namespace, group)
 	resp, err := req.Get(apiURL)
 
@@ -358,10 +362,31 @@ func (c *NacosClient) GetConfig(dataID, group string) (string, error) {
 	}
 
 	if resp.StatusCode() != 200 {
-		return "", fmt.Errorf("get config failed: status=%d", resp.StatusCode())
+		return "", fmt.Errorf("get config failed: status=%d, body=%s", resp.StatusCode(), string(resp.Body()))
 	}
 
-	return string(resp.Body()), nil
+	// Parse v3 response
+	var v3Resp V3Response
+	if err := json.Unmarshal(resp.Body(), &v3Resp); err != nil {
+		// If not JSON, return raw content (for backward compatibility)
+		return string(resp.Body()), nil
+	}
+	if v3Resp.Code != 0 {
+		return "", fmt.Errorf("get config failed: code=%d, message=%s", v3Resp.Code, v3Resp.Message)
+	}
+
+	// Parse config from data
+	var config Config
+	if err := json.Unmarshal(v3Resp.Data, &config); err != nil {
+		// Try to return raw data as string
+		var rawContent string
+		if err := json.Unmarshal(v3Resp.Data, &rawContent); err != nil {
+			return string(v3Resp.Data), nil
+		}
+		return rawContent, nil
+	}
+
+	return config.Content, nil
 }
 
 // PublishConfig publishes a configuration

--- a/internal/listener/config_listener.go
+++ b/internal/listener/config_listener.go
@@ -3,12 +3,18 @@ package listener
 import (
 	"context"
 	"crypto/md5"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
+)
+
+const (
+	// PollInterval is the interval between polling requests
+	PollInterval = 15 * time.Second
 )
 
 // ConfigItem represents a configuration item being monitored
@@ -38,14 +44,14 @@ func NewConfigListener(serverAddr, username, password string) *ConfigListener {
 		username:   username,
 		password:   password,
 		httpClient: &http.Client{
-			Timeout: 35 * time.Second, // Longer than long-polling timeout
+			Timeout: 30 * time.Second,
 		},
 	}
 }
 
-// Login gets access token for authentication
+// Login gets access token for authentication using v3 API
 func (l *ConfigListener) Login() error {
-	loginURL := fmt.Sprintf("http://%s/nacos/v1/auth/login", l.serverAddr)
+	loginURL := fmt.Sprintf("http://%s/nacos/v3/auth/user/login", l.serverAddr)
 
 	data := url.Values{}
 	data.Set("username", l.username)
@@ -66,7 +72,7 @@ func (l *ConfigListener) Login() error {
 		return fmt.Errorf("read login response failed: %w", err)
 	}
 
-	// Parse accessToken from response (simple JSON parsing)
+	// Parse accessToken from response
 	token := extractAccessToken(string(body))
 	if token == "" {
 		return fmt.Errorf("failed to extract access token from response")
@@ -76,8 +82,15 @@ func (l *ConfigListener) Login() error {
 	return nil
 }
 
-// StartListening starts long-polling for configuration changes
+// StartListening starts polling for configuration changes (v3 API doesn't support long-polling)
 func (l *ConfigListener) StartListening(items []ConfigItem, handler ChangeHandler, stopCh <-chan struct{}) error {
+	// Login first to get access token
+	if l.username != "" && l.password != "" {
+		if err := l.Login(); err != nil {
+			fmt.Printf("Warning: Login failed: %v\n", err)
+		}
+	}
+
 	// Keep a map of current items and their MD5
 	currentItems := make(map[string]*ConfigItem)
 	for i := range items {
@@ -94,230 +107,133 @@ func (l *ConfigListener) StartListening(items []ConfigItem, handler ChangeHandle
 		cancel()
 	}()
 
+	ticker := time.NewTicker(PollInterval)
+	defer ticker.Stop()
+
+	// Do an initial check immediately
+	l.pollConfigs(ctx, currentItems, handler)
+
 	for {
 		select {
 		case <-ctx.Done():
 			return nil
-		default:
-			// Build listening configs string
-			listeningConfigs := buildListeningConfigs(items)
+		case <-ticker.C:
+			l.pollConfigs(ctx, currentItems, handler)
+		}
+	}
+}
 
-			// Call listener API
-			changedItems, err := l.longPoll(ctx, listeningConfigs)
-			if err != nil {
-				// Check if context was cancelled
-				if ctx.Err() != nil {
-					return nil
+// pollConfigs polls all configurations and checks for changes
+func (l *ConfigListener) pollConfigs(ctx context.Context, currentItems map[string]*ConfigItem, handler ChangeHandler) {
+	for key, item := range currentItems {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		// Fetch latest config
+		content, newMD5, err := l.getConfig(item.DataID, item.Group, item.Tenant)
+		if err != nil {
+			// Check if it's a 404 error (config deleted)
+			if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "not exist") || strings.Contains(err.Error(), "config data not exist") {
+				// Check if MD5 is already empty (already processed deletion)
+				if item.MD5 == "" {
+					// Already deleted and MD5 reset, skip
+					continue
 				}
-				// Log error and retry
-				fmt.Printf("Long polling error: %v\n", err)
-				time.Sleep(5 * time.Second)
+				// First time seeing deletion, process it
+				if err := handler(item.DataID, item.Group, item.Tenant); err != nil {
+					fmt.Printf("Handler failed for %s/%s: %v\n", item.DataID, item.Group, err)
+				}
+				// Reset MD5 to empty so we can detect if skill is recreated
+				item.MD5 = ""
 				continue
 			}
-
-			// Process changes
-			if len(changedItems) > 0 {
-				for _, changed := range changedItems {
-					// Normalize tenant: if empty, try to find it from our items
-					normalizedTenant := changed.Tenant
-					if normalizedTenant == "" {
-						// Find tenant from currentItems based on dataID and group
-						for _, item := range currentItems {
-							if item.DataID == changed.DataID && item.Group == changed.Group {
-								normalizedTenant = item.Tenant
-								break
-							}
-						}
-					}
-					key := fmt.Sprintf("%s_%s_%s", changed.DataID, changed.Group, normalizedTenant)
-
-					// Fetch latest config
-					content, newMD5, err := l.getConfig(changed.DataID, changed.Group, changed.Tenant)
-					if err != nil {
-						// Check if it's a 404 error (config deleted)
-						if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "not exist") {
-							// Check if MD5 is already empty (already processed deletion)
-							if item, ok := currentItems[key]; ok {
-								if item.MD5 == "" {
-									// Already deleted and MD5 reset, skip
-									continue
-								}
-								// First time seeing deletion, process it
-								// Config was deleted, call handler to handle deletion
-								if err := handler(changed.DataID, changed.Group, changed.Tenant); err != nil {
-									fmt.Printf("Handler failed for %s/%s: %v\n", changed.DataID, changed.Group, err)
-								}
-								// Reset MD5 to empty so we can detect if skill is recreated
-								item.MD5 = ""
-							} else {
-								// Item not found in map, this shouldn't happen
-								fmt.Printf("Warning: item not found in currentItems: %s\n", key)
-							}
-							continue
-						}
-						fmt.Printf("Failed to fetch config %s/%s: %v\n", changed.DataID, changed.Group, err)
-						continue
-					}
-
-					// Check if MD5 actually changed
-					if item, ok := currentItems[key]; ok {
-						if item.MD5 == newMD5 {
-							// MD5 hasn't changed, skip
-							continue
-						}
-					}
-
-					// Call handler
-					if err := handler(changed.DataID, changed.Group, changed.Tenant); err != nil {
-						fmt.Printf("Handler failed for %s/%s: %v\n", changed.DataID, changed.Group, err)
-						continue
-					}
-
-					// Update MD5 only if handler succeeds
-					if item, ok := currentItems[key]; ok {
-						item.MD5 = newMD5
-					}
-
-					_ = content // Suppress unused warning
-				}
-			}
-		}
-	}
-}
-
-// longPoll performs a long-polling request
-func (l *ConfigListener) longPoll(ctx context.Context, listeningConfigs string) ([]ConfigItem, error) {
-	listenerURL := fmt.Sprintf("http://%s/nacos/v1/cs/configs/listener", l.serverAddr)
-
-	data := url.Values{}
-	data.Set("Listening-Configs", listeningConfigs)
-
-	if l.accessToken != "" {
-		listenerURL += "?accessToken=" + l.accessToken
-	}
-
-	req, err := http.NewRequestWithContext(ctx, "POST", listenerURL, strings.NewReader(data.Encode()))
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Set("Long-Pulling-Timeout", "30000")
-
-	resp, err := l.httpClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("listener returned status %d: %s", resp.StatusCode, string(body))
-	}
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	// Parse changed items
-	if len(body) == 0 {
-		return nil, nil // No changes
-	}
-
-	return parseChangedConfigs(string(body)), nil
-}
-
-// getConfig fetches the latest configuration content
-func (l *ConfigListener) getConfig(dataID, group, tenant string) (string, string, error) {
-	params := url.Values{}
-	params.Set("dataId", dataID)
-	params.Set("group", group)
-	if tenant != "" {
-		params.Set("tenant", tenant)
-	}
-	if l.accessToken != "" {
-		params.Set("accessToken", l.accessToken)
-	}
-
-	configURL := fmt.Sprintf("http://%s/nacos/v1/cs/configs?%s", l.serverAddr, params.Encode())
-
-	resp, err := l.httpClient.Get(configURL)
-	if err != nil {
-		return "", "", err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return "", "", fmt.Errorf("get config returned status %d: %s", resp.StatusCode, string(body))
-	}
-
-	content, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", "", err
-	}
-
-	// Get MD5 from response header
-	contentMD5 := resp.Header.Get("Content-MD5")
-	if contentMD5 == "" {
-		// Calculate MD5 if not provided
-		contentMD5 = calculateMD5(string(content))
-	}
-
-	return string(content), contentMD5, nil
-}
-
-// buildListeningConfigs builds the Listening-Configs parameter
-func buildListeningConfigs(items []ConfigItem) string {
-	var parts []string
-	for _, item := range items {
-		// Format: dataId\x02group\x02md5\x02tenant\x01
-		if item.Tenant != "" {
-			parts = append(parts, fmt.Sprintf("%s\x02%s\x02%s\x02%s\x01",
-				item.DataID, item.Group, item.MD5, item.Tenant))
-		} else {
-			parts = append(parts, fmt.Sprintf("%s\x02%s\x02%s\x01",
-				item.DataID, item.Group, item.MD5))
-		}
-	}
-
-	result := strings.Join(parts, "")
-	return url.QueryEscape(result)
-}
-
-// parseChangedConfigs parses the changed config list from response
-func parseChangedConfigs(response string) []ConfigItem {
-	// URL decode first
-	decoded, err := url.QueryUnescape(response)
-	if err != nil {
-		return nil
-	}
-
-	// Split by \x01 (line separator)
-	lines := strings.Split(decoded, "\x01")
-
-	var items []ConfigItem
-	for _, line := range lines {
-		if line == "" {
+			fmt.Printf("Failed to fetch config %s/%s: %v\n", item.DataID, item.Group, err)
 			continue
 		}
 
-		// Split by \x02 (field separator)
-		fields := strings.Split(line, "\x02")
-		if len(fields) >= 2 {
-			item := ConfigItem{
-				DataID: fields[0],
-				Group:  fields[1],
-			}
-			if len(fields) >= 4 {
-				item.Tenant = fields[3]
-			}
-			items = append(items, item)
+		// Check if MD5 actually changed
+		if item.MD5 == newMD5 {
+			// MD5 hasn't changed, skip
+			continue
 		}
+
+		// Call handler
+		if err := handler(item.DataID, item.Group, item.Tenant); err != nil {
+			fmt.Printf("Handler failed for %s/%s: %v\n", item.DataID, item.Group, err)
+			continue
+		}
+
+		// Update MD5 only if handler succeeds
+		item.MD5 = newMD5
+
+		_ = content // Suppress unused warning
+		_ = key     // Suppress unused warning
+	}
+}
+
+// getConfig fetches the latest configuration content using v3 client API
+func (l *ConfigListener) getConfig(dataID, group, tenant string) (string, string, error) {
+	params := url.Values{}
+	params.Set("dataId", dataID)
+	params.Set("groupName", group)
+	if tenant != "" {
+		params.Set("namespaceId", tenant)
 	}
 
-	return items
+	configURL := fmt.Sprintf("http://%s/nacos/v3/client/cs/config?%s", l.serverAddr, params.Encode())
+
+	req, err := http.NewRequest("GET", configURL, nil)
+	if err != nil {
+		return "", "", err
+	}
+	if l.accessToken != "" {
+		req.Header.Set("Authorization", "Bearer "+l.accessToken)
+	}
+
+	resp, err := l.httpClient.Do(req)
+	if err != nil {
+		return "", "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", "", err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", "", fmt.Errorf("get config returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	// Parse v3 response
+	var v3Resp struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+		Data    struct {
+			Content string `json:"content"`
+			Md5     string `json:"md5"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &v3Resp); err != nil {
+		// Fallback: treat as raw content
+		contentMD5 := calculateMD5(string(body))
+		return string(body), contentMD5, nil
+	}
+
+	if v3Resp.Code != 0 {
+		return "", "", fmt.Errorf("get config failed: code=%d, message=%s", v3Resp.Code, v3Resp.Message)
+	}
+
+	content := v3Resp.Data.Content
+	contentMD5 := v3Resp.Data.Md5
+	if contentMD5 == "" {
+		contentMD5 = calculateMD5(content)
+	}
+
+	return content, contentMD5, nil
 }
 
 // CalculateMD5 calculates MD5 hash of content (exported for reuse)
@@ -331,9 +247,9 @@ func calculateMD5(content string) string {
 	return CalculateMD5(content)
 }
 
-// extractAccessToken extracts access token from JSON response (simple parsing)
+// extractAccessToken extracts access token from JSON response
 func extractAccessToken(body string) string {
-	// Simple JSON parsing for {"accessToken":"xxx",...}
+	// Simple JSON parsing for {"accessToken":"xxx",...} or {"data":{"accessToken":"xxx",...}}
 	start := strings.Index(body, `"accessToken":"`)
 	if start == -1 {
 		return ""


### PR DESCRIPTION
- Migrate GetConfig to v3 client API (/nacos/v3/client/cs/config)
- Change config listener from long-polling to polling (15s interval)
- Add ~ home directory expansion for skill-get and skill-sync
- Bump version to 0.0.8