### PR TITLE
feat: support batch download for skill-get command

### DIFF
--- a/cmd/get_skill.go
+++ b/cmd/get_skill.go
@@ -17,12 +17,12 @@ var (
 )
 
 var getSkillCmd = &cobra.Command{
-	Use:   "skill-get [skillName]",
-	Short: "Get a skill and download it locally",
+	Use:   "skill-get [skillName...]",
+	Short: "Get one or more skills and download them locally",
 	Long:  help.SkillGet.FormatForCLI("nacos-cli"),
-	Args:  cobra.ExactArgs(1),
+	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		skillName := args[0]
+		skillNames := args
 
 		// Default output directory
 		if getSkillOutput == "" {
@@ -48,14 +48,42 @@ var getSkillCmd = &cobra.Command{
 		// Create skill service
 		skillService := skill.NewSkillService(nacosClient)
 
-		// Get skill
-		fmt.Printf("Fetching skill: %s...\n", skillName)
-		err := skillService.GetSkill(skillName, getSkillOutput)
-		checkError(err)
+		// Track results
+		var successCount, failCount int
+		var failedSkills []string
 
-		skillPath := filepath.Join(getSkillOutput, skillName)
-		fmt.Printf("Skill downloaded successfully!\n")
-		fmt.Printf("  Location: %s\n", skillPath)
+		// Process each skill
+		for i, skillName := range skillNames {
+			if len(skillNames) > 1 {
+				fmt.Printf("\n[%d/%d] ", i+1, len(skillNames))
+			}
+			fmt.Printf("Fetching skill: %s...\n", skillName)
+			err := skillService.GetSkill(skillName, getSkillOutput)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error: failed to download skill '%s': %v\n", skillName, err)
+				failCount++
+				failedSkills = append(failedSkills, skillName)
+			} else {
+				skillPath := filepath.Join(getSkillOutput, skillName)
+				fmt.Printf("Skill downloaded successfully!\n")
+				fmt.Printf("  Location: %s\n", skillPath)
+				successCount++
+			}
+		}
+
+		// Summary
+		if len(skillNames) > 1 {
+			fmt.Printf("\n========== Summary ==========\n")
+			fmt.Printf("Total: %d | Success: %d | Failed: %d\n", len(skillNames), successCount, failCount)
+			if failCount > 0 {
+				fmt.Printf("Failed skills: %s\n", strings.Join(failedSkills, ", "))
+			}
+		}
+
+		// Exit with error if any skill failed
+		if failCount > 0 {
+			os.Exit(1)
+		}
 	},
 }
 

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -353,14 +353,12 @@ func (t *Terminal) listSkills(args []string) {
 	}
 }
 
-// getSkill downloads a skill
+// getSkill downloads one or more skills
 func (t *Terminal) getSkill(args []string) {
 	if len(args) == 0 {
-		fmt.Println("\033[31mUsage:\033[0m skill-get <skillName>")
+		fmt.Println("\033[31mUsage:\033[0m skill-get <skillName> [skillName2...]")
 		return
 	}
-
-	skillName := args[0]
 
 	// Default output directory
 	homeDir, err := os.UserHomeDir()
@@ -370,16 +368,38 @@ func (t *Terminal) getSkill(args []string) {
 	}
 	outputDir := filepath.Join(homeDir, ".skills")
 
-	fmt.Printf("\033[90mDownloading skill: \033[33m%s\033[90m...\033[0m\n", skillName)
+	// Track results
+	var successCount, failCount int
+	var failedSkills []string
 
-	err = t.skillService.GetSkill(skillName, outputDir)
-	if err != nil {
-		fmt.Printf("\033[31mError:\033[0m %v\n", err)
-		return
+	// Process each skill
+	for i, skillName := range args {
+		if len(args) > 1 {
+			fmt.Printf("\n\033[90m[%d/%d] \033[0m", i+1, len(args))
+		}
+		fmt.Printf("\033[90mDownloading skill: \033[33m%s\033[90m...\033[0m\n", skillName)
+
+		err = t.skillService.GetSkill(skillName, outputDir)
+		if err != nil {
+			fmt.Printf("\033[31mError:\033[0m failed to download skill '%s': %v\n", skillName, err)
+			failCount++
+			failedSkills = append(failedSkills, skillName)
+		} else {
+			fmt.Printf("\033[32mSkill downloaded successfully!\033[0m\n")
+			fmt.Printf("  \033[90mLocation:\033[0m %s/%s\n", outputDir, skillName)
+			successCount++
+		}
 	}
 
-	fmt.Printf("\033[32mSkill downloaded successfully!\033[0m\n")
-	fmt.Printf("  \033[90mLocation:\033[0m %s/%s\n", outputDir, skillName)
+	// Summary for multiple skills
+	if len(args) > 1 {
+		fmt.Println()
+		fmt.Println("\033[36m========== Summary ==========\033[0m")
+		fmt.Printf("Total: %d | \033[32mSuccess:\033[0m %d | \033[31mFailed:\033[0m %d\n", len(args), successCount, failCount)
+		if failCount > 0 {
+			fmt.Printf("Failed skills: \033[31m%s\033[0m\n", strings.Join(failedSkills, ", "))
+		}
+	}
 }
 
 // uploadSkill uploads a skill

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nacos-group/cli",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "A command-line tool for managing Nacos configurations and AI skills",
   "bin": {
     "nacos-cli": "./bin/cli.js"


### PR DESCRIPTION
- CLI mode: skill-get now accepts multiple skill names
- Interactive mode: skill-get supports multiple skill names
- Add progress indicators [1/N] for batch operations
- Add summary report showing success/failed counts
- Continue processing remaining skills on individual failure

Change-Id: Ia662e2239f8aea29aa68b62aaf2ca98c5c831b65
Co-developed-by: Qoder <noreply@qoder.com>