### PR TITLE
docs: fix placeholder links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ nacos-cli --help
 
 ### Download Binary
 
-Download the latest release from [GitHub Releases](https://github.com/yourusername/nacos-cli/releases).
+Download the latest release from [GitHub Releases](https://github.com/nacos-group/nacos-cli/releases).
 
 ### Build from Source
 
 ```bash
 # Clone the repository
-git clone https://github.com/yourusername/nacos-cli.git
+git clone https://github.com/nacos-group/nacos-cli.git
 cd nacos-cli
 
 # Build


### PR DESCRIPTION
## Summary
- Replace `yourusername` placeholder with `nacos-group` in GitHub Releases link and git clone URL

## Test plan
- [x] Verify links point to correct repository