### PR TITLE
chore: update Go module path from nov11 to nacos-group

### DIFF
--- a/cmd/get_agentspec.go
+++ b/cmd/get_agentspec.go
@@ -6,9 +6,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/nov11/nacos-cli/internal/agentspec"
-	"github.com/nov11/nacos-cli/internal/help"
-	"github.com/nov11/nacos-cli/internal/util"
+	"github.com/nacos-group/nacos-cli/internal/agentspec"
+	"github.com/nacos-group/nacos-cli/internal/help"
+	"github.com/nacos-group/nacos-cli/internal/util"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/get_config.go
+++ b/cmd/get_config.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/nov11/nacos-cli/internal/help"
+	"github.com/nacos-group/nacos-cli/internal/help"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/get_skill.go
+++ b/cmd/get_skill.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/nov11/nacos-cli/internal/help"
-	"github.com/nov11/nacos-cli/internal/skill"
+	"github.com/nacos-group/nacos-cli/internal/help"
+	"github.com/nacos-group/nacos-cli/internal/skill"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"github.com/nov11/nacos-cli/internal/terminal"
+	"github.com/nacos-group/nacos-cli/internal/terminal"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/list_agentspec.go
+++ b/cmd/list_agentspec.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/nov11/nacos-cli/internal/agentspec"
-	"github.com/nov11/nacos-cli/internal/help"
-	"github.com/nov11/nacos-cli/internal/util"
+	"github.com/nacos-group/nacos-cli/internal/agentspec"
+	"github.com/nacos-group/nacos-cli/internal/help"
+	"github.com/nacos-group/nacos-cli/internal/util"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/list_config.go
+++ b/cmd/list_config.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/nov11/nacos-cli/internal/help"
+	"github.com/nacos-group/nacos-cli/internal/help"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/list_skill.go
+++ b/cmd/list_skill.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/nov11/nacos-cli/internal/help"
-	"github.com/nov11/nacos-cli/internal/skill"
-	"github.com/nov11/nacos-cli/internal/util"
+	"github.com/nacos-group/nacos-cli/internal/help"
+	"github.com/nacos-group/nacos-cli/internal/skill"
+	"github.com/nacos-group/nacos-cli/internal/util"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -6,9 +6,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/nov11/nacos-cli/internal/client"
-	"github.com/nov11/nacos-cli/internal/config"
-	"github.com/nov11/nacos-cli/internal/terminal"
+	"github.com/nacos-group/nacos-cli/internal/client"
+	"github.com/nacos-group/nacos-cli/internal/config"
+	"github.com/nacos-group/nacos-cli/internal/terminal"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/publish_skill.go
+++ b/cmd/publish_skill.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/nov11/nacos-cli/internal/help"
-	"github.com/nov11/nacos-cli/internal/skill"
+	"github.com/nacos-group/nacos-cli/internal/help"
+	"github.com/nacos-group/nacos-cli/internal/skill"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/nov11/nacos-cli/internal/client"
-	"github.com/nov11/nacos-cli/internal/config"
-	"github.com/nov11/nacos-cli/internal/terminal"
+	"github.com/nacos-group/nacos-cli/internal/client"
+	"github.com/nacos-group/nacos-cli/internal/config"
+	"github.com/nacos-group/nacos-cli/internal/terminal"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/set_config.go
+++ b/cmd/set_config.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/nov11/nacos-cli/internal/help"
+	"github.com/nacos-group/nacos-cli/internal/help"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/upload_agentspec.go
+++ b/cmd/upload_agentspec.go
@@ -6,9 +6,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/nov11/nacos-cli/internal/agentspec"
-	"github.com/nov11/nacos-cli/internal/help"
-	"github.com/nov11/nacos-cli/internal/util"
+	"github.com/nacos-group/nacos-cli/internal/agentspec"
+	"github.com/nacos-group/nacos-cli/internal/help"
+	"github.com/nacos-group/nacos-cli/internal/util"
 	"github.com/spf13/cobra"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/nov11/nacos-cli
+module github.com/nacos-group/nacos-cli
 
 go 1.21
 

--- a/internal/agentspec/agentspec_service.go
+++ b/internal/agentspec/agentspec_service.go
@@ -14,7 +14,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/nov11/nacos-cli/internal/client"
+	"github.com/nacos-group/nacos-cli/internal/client"
 )
 
 // AgentSpecService handles agentspec-related operations

--- a/internal/skill/skill_service.go
+++ b/internal/skill/skill_service.go
@@ -13,7 +13,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/nov11/nacos-cli/internal/client"
+	"github.com/nacos-group/nacos-cli/internal/client"
 	"gopkg.in/yaml.v3"
 )
 

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -8,10 +8,10 @@ import (
 	"strings"
 
 	"github.com/chzyer/readline"
-	"github.com/nov11/nacos-cli/internal/agentspec"
-	"github.com/nov11/nacos-cli/internal/client"
-	"github.com/nov11/nacos-cli/internal/help"
-	"github.com/nov11/nacos-cli/internal/skill"
+	"github.com/nacos-group/nacos-cli/internal/agentspec"
+	"github.com/nacos-group/nacos-cli/internal/client"
+	"github.com/nacos-group/nacos-cli/internal/help"
+	"github.com/nacos-group/nacos-cli/internal/skill"
 )
 
 const defaultDescLimit = 200

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"github.com/nov11/nacos-cli/cmd"
+	"github.com/nacos-group/nacos-cli/cmd"
 )
 
 func main() {


### PR DESCRIPTION
Fixes https://github.com/nacos-group/nacos-cli/issues/25

## Summary

- Update Go module path from `github.com/nov11/nacos-cli` to `github.com/nacos-group/nacos-cli`
- All import paths across 17 files updated accordingly
- Enables `go install github.com/nacos-group/nacos-cli@latest` to work correctly

## Verification

- `go build ./...` passes
- `go vet ./...` passes
- No references to `nov11` remain in codebase