### PR TITLE
feat: add --version flag with build info injection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ BUILD_DIR=build
 # Version
 VERSION?=0.0.11
 
+# Git info
+COMMIT=$(shell git rev-parse --short HEAD 2>/dev/null || echo "none")
+DATE=$(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
+
 # Go parameters
 GOCMD=go
 GOBUILD=$(GOCMD) build
@@ -16,12 +20,13 @@ GOCLEAN=$(GOCMD) clean
 GOTEST=$(GOCMD) test
 GOGET=$(GOCMD) get
 GOMOD=$(GOCMD) mod
+LDFLAGS=-s -w -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)
 
 # Build the project
 build:
 	@echo "Building $(BINARY_NAME)..."
 	@mkdir -p $(BUILD_DIR)
-	$(GOBUILD) -o $(BUILD_DIR)/$(BINARY_NAME) -v
+	$(GOBUILD) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME) -v
 
 # Build for all platforms
 build-all: build-linux build-darwin build-windows package-all
@@ -29,20 +34,20 @@ build-all: build-linux build-darwin build-windows package-all
 build-linux:
 	@echo "Building for Linux..."
 	@mkdir -p $(BUILD_DIR)/$(VERSION)
-	GOOS=linux GOARCH=amd64 $(GOBUILD) -o $(BUILD_DIR)/$(BINARY_NAME)-$(VERSION)-linux-amd64 -v
-	GOOS=linux GOARCH=arm64 $(GOBUILD) -o $(BUILD_DIR)/$(BINARY_NAME)-$(VERSION)-linux-arm64 -v
+	GOOS=linux GOARCH=amd64 $(GOBUILD) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME)-$(VERSION)-linux-amd64 -v
+	GOOS=linux GOARCH=arm64 $(GOBUILD) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME)-$(VERSION)-linux-arm64 -v
 
 build-darwin:
 	@echo "Building for macOS..."
 	@mkdir -p $(BUILD_DIR)/$(VERSION)
-	GOOS=darwin GOARCH=amd64 $(GOBUILD) -o $(BUILD_DIR)/$(BINARY_NAME)-$(VERSION)-darwin-amd64 -v
-	GOOS=darwin GOARCH=arm64 $(GOBUILD) -o $(BUILD_DIR)/$(BINARY_NAME)-$(VERSION)-darwin-arm64 -v
+	GOOS=darwin GOARCH=amd64 $(GOBUILD) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME)-$(VERSION)-darwin-amd64 -v
+	GOOS=darwin GOARCH=arm64 $(GOBUILD) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME)-$(VERSION)-darwin-arm64 -v
 
 build-windows:
 	@echo "Building for Windows..."
 	@mkdir -p $(BUILD_DIR)/$(VERSION)
-	GOOS=windows GOARCH=amd64 $(GOBUILD) -o $(BUILD_DIR)/$(BINARY_NAME)-$(VERSION)-windows-amd64.exe -v
-	GOOS=windows GOARCH=arm64 $(GOBUILD) -o $(BUILD_DIR)/$(BINARY_NAME)-$(VERSION)-windows-arm64.exe -v
+	GOOS=windows GOARCH=amd64 $(GOBUILD) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME)-$(VERSION)-windows-amd64.exe -v
+	GOOS=windows GOARCH=arm64 $(GOBUILD) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME)-$(VERSION)-windows-arm64.exe -v
 
 # Package all binaries into versioned directory as zip files
 package-all:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -154,6 +154,12 @@ Examples:
 	},
 }
 
+// SetVersionInfo sets the version information for the root command.
+// Called from main.go with values injected via ldflags.
+func SetVersionInfo(version, commit, date string) {
+	rootCmd.Version = fmt.Sprintf("%s (commit: %s, built: %s)", version, commit, date)
+}
+
 // Execute runs the root command
 func Execute() error {
 	return rootCmd.Execute()

--- a/main.go
+++ b/main.go
@@ -6,7 +6,15 @@ import (
 	"github.com/nov11/nacos-cli/cmd"
 )
 
+// Set via ldflags at build time.
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
 func main() {
+	cmd.SetVersionInfo(version, commit, date)
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)
 	}


### PR DESCRIPTION
Fixes https://github.com/nacos-group/nacos-cli/issues/23

## Summary

- Add `version`, `commit`, `date` variables in `main.go`, set via ldflags at build time
- Register version info with cobra's `rootCmd.Version` so `nacos-cli --version` works
- Update Makefile to inject version info via ldflags in all build targets

## Usage

```bash
# Default (dev build)
$ nacos-cli --version
nacos-cli version dev (commit: none, built: unknown)

# make build (auto-injects from git)
$ make build && ./build/nacos-cli --version
nacos-cli version 0.0.11 (commit: abc1234, built: 2026-03-23T13:17:10Z)

# GoReleaser / custom ldflags
$ go build -ldflags "-X main.version=1.0.0 -X main.commit=abc1234 -X main.date=2026-03-23"
```