### PR TITLE
refactor(terminal): improve command parsing and enhance user prompts

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,38 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="AklessInspection" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="AuthTagInspection" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="JavaPlaintextAkInspection" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="MissApiTokenInspection" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="RCE-Aviator" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="RCE-Groovy" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="RCE-Jdbc" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="RCE-Jpython" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="RCE-Mvel" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="RCE-Ognl" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="RCE-Qlexpress" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="RCE-ScriptEngine" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="RCE-Spel" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="RCE-Yaml" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="RCE-bsh" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="RCE-desearialize" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="RCE-kubeconfig" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="RCE-staragent" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="RamcheckerSingletonInspection" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="RceJdbcInspection" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="ReusableAuthContextOrRequestInspection" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="SSRF" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="SSTI-FreeMarker" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="SSTI-Jinjia" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="SSTI-Pebble" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="SSTI-Thymeleaf" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="SSTI-Velocity" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ScaInspection" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="SourceInspection" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="StartSSRFNetHookCheckingInspection" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="WithSSRFCheckingInspection" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="XmlPlaintextAkInspection" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="YamlPlaintextAkInspection" enabled="true" level="WARNING" enabled_by_default="true" />
+  </profile>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CheckStyle-IDEA">
+    <option name="configuration">
+      <map>
+        <entry key="checkstyle-version" value="8.11" />
+        <entry key="copy-libs" value="false" />
+        <entry key="location-0" value="BUNDLED:(bundled):Sun Checks" />
+        <entry key="location-1" value="BUNDLED:(bundled):Google Checks" />
+        <entry key="scan-before-checkin" value="false" />
+        <entry key="scanscope" value="JavaOnly" />
+        <entry key="suppress-errors" value="false" />
+      </map>
+    </option>
+  </component>
+  <component name="CheckStyle-IDEA-workspace">
+    <option name="configuration">
+      <map>
+        <entry key="last-active-plugin-version" value="5.21.1" />
+      </map>
+    </option>
+  </component>
+  <component name="ProjectInspectionProfilesVisibleTreeState">
+    <entry key="Project Default">
+      <profile-state>
+        <expanded-state>
+          <State>
+            <id />
+          </State>
+          <State>
+            <id>Plugin DevKit</id>
+          </State>
+        </expanded-state>
+      </profile-state>
+    </entry>
+  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="17" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/nacos-cli.iml" filepath="$PROJECT_DIR$/.idea/nacos-cli.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/nacos-cli.iml
+++ b/.idea/nacos-cli.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ChangeListManager">
+    <list default="true" id="9b421d98-3962-4f3f-be84-94987c042d9a" name="Changes" comment="" />
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="CopilotPersistence">
+    <persistenceIdMap>
+      <entry key="_/Users/xiweng.yy/Documents/go/opensource/nacos-cli" value="3BNCFhF0ho2zRkr7PED3kMX689N" />
+    </persistenceIdMap>
+  </component>
+  <component name="DefaultGradleProjectSettings">
+    <option name="isMigrated" value="true" />
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="GradleLocalSettings">
+    <option name="myGradleUserHome" value="$MAVEN_REPOSITORY$" />
+    <option name="projectSyncType">
+      <map>
+        <entry key="$PROJECT_DIR$/../../../java/mc/forge-1.12.2-14.23.5.2768-mdk/forge-1.12.2-14.23.5.2768-mdk" value="PREVIEW" />
+        <entry key="$PROJECT_DIR$/../../../java/mc/forge-1.15.2-31.1.30-mdk" value="PREVIEW" />
+      </map>
+    </option>
+  </component>
+  <component name="MavenImportPreferences">
+    <option name="generalSettings">
+      <MavenGeneralSettings>
+        <option name="userSettingsFile" value="$USER_HOME$/apache-maven-3.6.3/conf/setting-taobao.xml" />
+      </MavenGeneralSettings>
+    </option>
+  </component>
+  <component name="ProjectColorInfo"><![CDATA[{
+  "associatedIndex": 3
+}]]></component>
+  <component name="ProjectId" id="3BNCFhF0ho2zRkr7PED3kMX689N" />
+  <component name="ProjectLevelVcsManager" settingsEditedManually="true" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+    <option name="showScratchesAndConsoles" value="false" />
+    <option name="showVisibilityIcons" value="true" />
+  </component>
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "git-widget-placeholder": "main",
+    "kotlin-language-version-configured": "true",
+    "nodejs_package_manager_path": "npm"
+  }
+}]]></component>
+  <component name="RunManager">
+    <configuration default="true" type="Applet">
+      <option name="POLICY_FILE" value="$APPLICATION_HOME_DIR$/bin/appletviewer.policy" />
+      <method v="2">
+        <option name="Make" enabled="true" />
+      </method>
+    </configuration>
+    <configuration default="true" type="#org.jetbrains.idea.devkit.run.PluginConfigurationType">
+      <module name="" />
+      <option name="VM_PARAMETERS" value="-Xmx512m -Xms256m -XX:MaxPermSize=250m -ea" />
+      <option name="PROGRAM_PARAMETERS" />
+      <predefined_log_file enabled="true" id="idea.log" />
+      <method v="2">
+        <option name="Make" enabled="true" />
+      </method>
+    </configuration>
+    <configuration default="true" type="Application" factoryName="Application">
+      <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+      <method v="2">
+        <option name="Make" enabled="true" />
+      </method>
+    </configuration>
+    <configuration default="true" type="JUnit" factoryName="JUnit">
+      <option name="TEST_OBJECT" value="class" />
+      <option name="WORKING_DIRECTORY" value="$MODULE_DIR$" />
+      <method v="2">
+        <option name="Make" enabled="true" />
+      </method>
+    </configuration>
+    <configuration default="true" type="TestNG">
+      <option name="TEST_OBJECT" value="CLASS" />
+      <option name="WORKING_DIRECTORY" value="$MODULE_DIR$" />
+      <properties />
+      <listeners />
+      <method v="2">
+        <option name="Make" enabled="true" />
+      </method>
+    </configuration>
+  </component>
+  <component name="SharedIndexes">
+    <attachedChunks>
+      <set>
+        <option value="bundled-jdk-9f38398b9061-39b83d9b5494-intellij.indexing.shared.core-IU-241.17011.79" />
+        <option value="bundled-js-predefined-1d06a55b98c1-0b3e54e931b4-JavaScript-IU-241.17011.79" />
+      </set>
+    </attachedChunks>
+  </component>
+  <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
+  <component name="SvnConfiguration">
+    <configuration>$USER_HOME$/.subversion</configuration>
+  </component>
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="9b421d98-3962-4f3f-be84-94987c042d9a" name="Changes" comment="" />
+      <created>1774320040549</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1774320040549</updated>
+      <workItem from="1774320042470" duration="2000" />
+    </task>
+    <servers />
+  </component>
+  <component name="TypeScriptGeneratedFilesManager">
+    <option name="version" value="3" />
+  </component>
+  <component name="github-copilot-workspace">
+    <instructionFileLocations>
+      <option value=".github/instructions" />
+    </instructionFileLocations>
+    <promptFileLocations>
+      <option value=".github/prompts" />
+    </promptFileLocations>
+  </component>
+</project>

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -35,6 +35,29 @@ func NewTerminal(nacosClient *client.NacosClient) *Terminal {
 	}
 }
 
+// getPrompt returns the prompt string with user info
+func (t *Terminal) getPrompt() string {
+	// Show abbreviated user info in prompt
+	switch t.client.AuthType {
+	case client.AuthTypeNacos:
+		if t.client.Username != "" {
+			return fmt.Sprintf("\033[32m%s@nacos>\033[0m ", t.client.Username)
+		}
+	case client.AuthTypeAliyun:
+		if t.client.AccessKey != "" {
+			// Show first 8 chars of access key
+			ak := t.client.AccessKey
+			if len(ak) > 8 {
+				ak = ak[:8]
+			}
+			return fmt.Sprintf("\033[32m%s@nacos>\033[0m ", ak)
+		}
+	case client.AuthTypeToken:
+		return "\033[32m(token)nacos>\033[0m "
+	}
+	return "\033[32mnacos>\033[0m "
+}
+
 // completer provides command auto-completion
 func completer() *readline.PrefixCompleter {
 	return readline.NewPrefixCompleter(
@@ -92,7 +115,7 @@ func (t *Terminal) Start() error {
 	historyFile := filepath.Join(os.TempDir(), ".nacos-cli-history")
 
 	rl, err := readline.NewEx(&readline.Config{
-		Prompt:          "\033[32mnacos>\033[0m ",
+		Prompt:          t.getPrompt(),
 		HistoryFile:     historyFile,
 		AutoComplete:    completer(),
 		InterruptPrompt: "^C",
@@ -139,6 +162,21 @@ func (t *Terminal) printWelcome() {
 	if t.client.Namespace != "" {
 		fmt.Printf("\033[33mNamespace:\033[0m %s\n", t.client.Namespace)
 	}
+	// Show user info based on auth type
+	switch t.client.AuthType {
+	case client.AuthTypeNacos:
+		if t.client.Username != "" {
+			fmt.Printf("\033[33mUser:\033[0m %s (username/password)\n", t.client.Username)
+		}
+	case client.AuthTypeAliyun:
+		if t.client.AccessKey != "" {
+			fmt.Printf("\033[33mUser:\033[0m %s (AccessKey)\n", t.client.AccessKey)
+		}
+	case client.AuthTypeToken:
+		fmt.Printf("\033[33mAuth:\033[0m Token (authenticated)\n")
+	case client.AuthTypeNone:
+		fmt.Printf("\033[33mAuth:\033[0m None (public access)\n")
+	}
 	fmt.Println()
 	fmt.Println("\033[90mType '\033[0mhelp\033[90m' for available commands\033[0m")
 	fmt.Println("\033[90mPress '\033[0mTab\033[90m' for auto-completion\033[0m")
@@ -146,15 +184,61 @@ func (t *Terminal) printWelcome() {
 	fmt.Println()
 }
 
-// handleCommand handles user command
-func (t *Terminal) handleCommand(input string) {
+// parseCommandArgs parses command line arguments, properly handling flags and their values
+// For example: "skill-get my-skill --label latest -o /path" should recognize:
+//   - skill name: my-skill
+//   - flags: --label latest, -o /path
+// This prevents flags and their values from being treated as additional skill names
+func parseCommandArgs(input string) (cmd string, args []string) {
 	parts := strings.Fields(input)
 	if len(parts) == 0 {
-		return
+		return "", nil
 	}
 
-	cmd := parts[0]
-	args := parts[1:]
+	cmd = parts[0]
+	args = make([]string, 0, len(parts)-1)
+
+	// Parse remaining parts, handling flags properly
+	for i := 1; i < len(parts); i++ {
+		arg := parts[i]
+		
+		// Check if this is a flag
+		if strings.HasPrefix(arg, "-") {
+			args = append(args, arg)
+			// Check if flag takes a value (not a boolean flag like --help or --all)
+			// Flags that don't take values
+			booleanFlags := map[string]bool{
+				"--help": true, "-h": true,
+				"--all": true,
+			}
+			
+			// If it's a long flag (--flag), check if value is separate
+			if strings.HasPrefix(arg, "--") && !strings.Contains(arg, "=") {
+				if !booleanFlags[arg] && i+1 < len(parts) && !strings.HasPrefix(parts[i+1], "-") {
+					// Next arg is the value, skip it in main args (it will be handled by flag parser)
+					args = append(args, parts[i+1])
+					i++ // Skip next arg since we consumed it
+				}
+			} else if strings.HasPrefix(arg, "-") && !strings.Contains(arg, "=") {
+				// Short flag (-o), check if value is separate
+				if !booleanFlags[arg] && len(arg) == 2 && i+1 < len(parts) && !strings.HasPrefix(parts[i+1], "-") {
+					// Next arg is the value
+					args = append(args, parts[i+1])
+					i++ // Skip next arg
+				}
+			}
+		} else {
+			// Not a flag, treat as positional argument
+			args = append(args, arg)
+		}
+	}
+
+	return cmd, args
+}
+
+// handleCommand handles user command
+func (t *Terminal) handleCommand(input string) {
+	cmd, args := parseCommandArgs(input)
 
 	switch cmd {
 	case "help":
@@ -296,7 +380,37 @@ func (t *Terminal) showServerInfo() {
 	fmt.Printf("  Server:    %s\n", t.client.ServerAddr)
 	fmt.Printf("  Username:  %s\n", t.client.Username)
 	fmt.Printf("  Namespace: %s\n", t.client.Namespace)
+	fmt.Printf("  Auth Type: %s\n", t.getAuthTypeDisplay())
 	fmt.Println("─────────────────────────────────────────────────────────")
+}
+
+// getAuthTypeDisplay returns a human-readable auth type description
+func (t *Terminal) getAuthTypeDisplay() string {
+	switch t.client.AuthType {
+	case client.AuthTypeNacos:
+		if t.client.Username != "" {
+			return fmt.Sprintf("nacos (user: %s)", t.client.Username)
+		}
+		return "nacos"
+	case client.AuthTypeAliyun:
+		if t.client.AccessKey != "" {
+			return fmt.Sprintf("aliyun (accessKey: %s...)", t.client.AccessKey[:min(8, len(t.client.AccessKey))])
+		}
+		return "aliyun"
+	case client.AuthTypeToken:
+		return "token (authenticated)"
+	case client.AuthTypeNone:
+		return "none (public access)"
+	default:
+		return t.client.AuthType
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
 }
 
 // namespace shows or switches namespace
@@ -394,26 +508,83 @@ func (t *Terminal) getSkill(args []string) {
 		return
 	}
 
-	// Default output directory
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		fmt.Printf("\033[31mError:\033[0m %v\n", err)
+	// Parse flags from args
+	var skillNames []string
+	var outputDir string
+	var version, label string
+
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		
+		if arg == "--version" && i+1 < len(args) {
+			i++
+			version = args[i]
+		} else if strings.HasPrefix(arg, "--version=") {
+			version = strings.TrimPrefix(arg, "--version=")
+		} else if arg == "-o" && i+1 < len(args) {
+			i++
+			outputDir = args[i]
+		} else if strings.HasPrefix(arg, "-o=") {
+			outputDir = strings.TrimPrefix(arg, "-o=")
+		} else if arg == "--label" && i+1 < len(args) {
+			i++
+			label = args[i]
+		} else if strings.HasPrefix(arg, "--label=") {
+			label = strings.TrimPrefix(arg, "--label=")
+		} else if strings.HasPrefix(arg, "-") {
+			// Unknown flag, skip
+			continue
+		} else {
+			// Positional argument (skill name)
+			skillNames = append(skillNames, arg)
+		}
+	}
+
+	if len(skillNames) == 0 {
+		fmt.Println("\033[31mError:\033[0m no skill names specified")
 		return
 	}
-	outputDir := filepath.Join(homeDir, ".skills")
+
+	// Default output directory
+	if outputDir == "" {
+		homeDir, homeErr := os.UserHomeDir()
+		if homeErr != nil {
+			fmt.Printf("\033[31mError:\033[0m %v\n", homeErr)
+			return
+		}
+		outputDir = filepath.Join(homeDir, ".skills")
+	} else {
+		// Expand ~ to home directory
+		if strings.HasPrefix(outputDir, "~/") {
+			homeDir, homeErr := os.UserHomeDir()
+			if homeErr != nil {
+				fmt.Printf("\033[31mError:\033[0m %v\n", homeErr)
+				return
+			}
+			outputDir = filepath.Join(homeDir, outputDir[2:])
+		} else if outputDir == "~" {
+			homeDir, homeErr := os.UserHomeDir()
+			if homeErr != nil {
+				fmt.Printf("\033[31mError:\033[0m %v\n", homeErr)
+				return
+			}
+			outputDir = homeDir
+		}
+	}
 
 	// Track results
 	var successCount, failCount int
 	var failedSkills []string
+	var err error
 
 	// Process each skill
-	for i, skillName := range args {
-		if len(args) > 1 {
-			fmt.Printf("\n\033[90m[%d/%d] \033[0m", i+1, len(args))
+	for i, skillName := range skillNames {
+		if len(skillNames) > 1 {
+			fmt.Printf("\n\033[90m[%d/%d] \033[0m", i+1, len(skillNames))
 		}
 		fmt.Printf("\033[90mDownloading skill: \033[33m%s\033[90m...\033[0m\n", skillName)
 
-		err = t.skillService.GetSkill(skillName, outputDir, "", "")
+		err = t.skillService.GetSkill(skillName, outputDir, version, label)
 		if err != nil {
 			fmt.Printf("\033[31mError:\033[0m failed to download skill '%s': %v\n", skillName, err)
 			failCount++
@@ -426,10 +597,10 @@ func (t *Terminal) getSkill(args []string) {
 	}
 
 	// Summary for multiple skills
-	if len(args) > 1 {
+	if len(skillNames) > 1 {
 		fmt.Println()
 		fmt.Println("\033[36m========== Summary ==========\033[0m")
-		fmt.Printf("Total: %d | \033[32mSuccess:\033[0m %d | \033[31mFailed:\033[0m %d\n", len(args), successCount, failCount)
+		fmt.Printf("Total: %d | \033[32mSuccess:\033[0m %d | \033[31mFailed:\033[0m %d\n", len(skillNames), successCount, failCount)
 		if failCount > 0 {
 			fmt.Printf("Failed skills: \033[31m%s\033[0m\n", strings.Join(failedSkills, ", "))
 		}
@@ -911,26 +1082,83 @@ func (t *Terminal) getAgentSpec(args []string) {
 		return
 	}
 
-	// Default output directory
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		fmt.Printf("\033[31mError:\033[0m %v\n", err)
+	// Parse flags from args
+	var specNames []string
+	var outputDir string
+	var version, label string
+
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		
+		if arg == "--version" && i+1 < len(args) {
+			i++
+			version = args[i]
+		} else if strings.HasPrefix(arg, "--version=") {
+			version = strings.TrimPrefix(arg, "--version=")
+		} else if arg == "-o" && i+1 < len(args) {
+			i++
+			outputDir = args[i]
+		} else if strings.HasPrefix(arg, "-o=") {
+			outputDir = strings.TrimPrefix(arg, "-o=")
+		} else if arg == "--label" && i+1 < len(args) {
+			i++
+			label = args[i]
+		} else if strings.HasPrefix(arg, "--label=") {
+			label = strings.TrimPrefix(arg, "--label=")
+		} else if strings.HasPrefix(arg, "-") {
+			// Unknown flag, skip
+			continue
+		} else {
+			// Positional argument (spec name)
+			specNames = append(specNames, arg)
+		}
+	}
+
+	if len(specNames) == 0 {
+		fmt.Println("\033[31mError:\033[0m no agent spec names specified")
 		return
 	}
-	outputDir := filepath.Join(homeDir, ".agentspecs")
+
+	// Default output directory
+	if outputDir == "" {
+		homeDir, homeErr := os.UserHomeDir()
+		if homeErr != nil {
+			fmt.Printf("\033[31mError:\033[0m %v\n", homeErr)
+			return
+		}
+		outputDir = filepath.Join(homeDir, ".agentspecs")
+	} else {
+		// Expand ~ to home directory
+		if strings.HasPrefix(outputDir, "~/") {
+			homeDir, homeErr := os.UserHomeDir()
+			if homeErr != nil {
+				fmt.Printf("\033[31mError:\033[0m %v\n", homeErr)
+				return
+			}
+			outputDir = filepath.Join(homeDir, outputDir[2:])
+		} else if outputDir == "~" {
+			homeDir, homeErr := os.UserHomeDir()
+			if homeErr != nil {
+				fmt.Printf("\033[31mError:\033[0m %v\n", homeErr)
+				return
+			}
+			outputDir = homeDir
+		}
+	}
 
 	// Track results
 	var successCount, failCount int
 	var failedSpecs []string
+	var err error
 
-	// Process each agent spec
-	for i, specName := range args {
-		if len(args) > 1 {
-			fmt.Printf("\n\033[90m[%d/%d] \033[0m", i+1, len(args))
+	// Process each spec
+	for i, specName := range specNames {
+		if len(specNames) > 1 {
+			fmt.Printf("\n\033[90m[%d/%d] \033[0m", i+1, len(specNames))
 		}
 		fmt.Printf("\033[90mDownloading agent spec: \033[33m%s\033[90m...\033[0m\n", specName)
 
-		err = t.agentSpecService.GetAgentSpec(specName, outputDir, "", "")
+		err = t.agentSpecService.GetAgentSpec(specName, outputDir, version, label)
 		if err != nil {
 			fmt.Printf("\033[31mError:\033[0m failed to download agent spec '%s': %v\n", specName, err)
 			failCount++
@@ -943,10 +1171,10 @@ func (t *Terminal) getAgentSpec(args []string) {
 	}
 
 	// Summary for multiple specs
-	if len(args) > 1 {
+	if len(specNames) > 1 {
 		fmt.Println()
 		fmt.Println("\033[36m========== Summary ==========\033[0m")
-		fmt.Printf("Total: %d | \033[32mSuccess:\033[0m %d | \033[31mFailed:\033[0m %d\n", len(args), successCount, failCount)
+		fmt.Printf("Total: %d | \033[32mSuccess:\033[0m %d | \033[31mFailed:\033[0m %d\n", len(specNames), successCount, failCount)
 		if failCount > 0 {
 			fmt.Printf("Failed agent specs: \033[31m%s\033[0m\n", strings.Join(failedSpecs, ", "))
 		}

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -1,0 +1,171 @@
+package terminal
+
+import (
+	"testing"
+)
+
+func TestParseCommandArgs(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		expectedCmd   string
+		expectedArgs  []string
+		description   string
+	}{
+		{
+			name:         "simple command without flags",
+			input:        "skill-get my-skill",
+			expectedCmd:  "skill-get",
+			expectedArgs: []string{"my-skill"},
+			description:  "Basic command with single positional argument",
+		},
+		{
+			name:         "command with long flag and value",
+			input:        "skill-get my-skill --label latest",
+			expectedCmd:  "skill-get",
+			expectedArgs: []string{"my-skill", "--label", "latest"},
+			description:  "Long flag with separate value should be grouped together",
+		},
+		{
+			name:         "command with short flag and value",
+			input:        "skill-get my-skill -o /path/to/output",
+			expectedCmd:  "skill-get",
+			expectedArgs: []string{"my-skill", "-o", "/path/to/output"},
+			description:  "Short flag with value should be grouped together",
+		},
+		{
+			name:         "command with multiple flags",
+			input:        "skill-get my-skill --version v1 --label stable",
+			expectedCmd:  "skill-get",
+			expectedArgs: []string{"my-skill", "--version", "v1", "--label", "stable"},
+			description:  "Multiple flags with values should all be parsed correctly",
+		},
+		{
+			name:         "command with boolean flag",
+			input:        "skill-publish --help",
+			expectedCmd:  "skill-publish",
+			expectedArgs: []string{"--help"},
+			description:  "Boolean flag should not consume next argument",
+		},
+		{
+			name:         "command with mixed args and flags",
+			input:        "skill-get skill1 skill2 --label prod -o /tmp",
+			expectedCmd:  "skill-get",
+			expectedArgs: []string{"skill1", "skill2", "--label", "prod", "-o", "/tmp"},
+			description:  "Multiple positional args with flags should work",
+		},
+		{
+			name:         "agentspec command with flags",
+			input:        "agentspec-get my-spec --label prod",
+			expectedCmd:  "agentspec-get",
+			expectedArgs: []string{"my-spec", "--label", "prod"},
+			description:  "AgentSpec command with long flag",
+		},
+		{
+			name:         "config-set with file flag",
+			input:        "config-set data-id group -f /path/to/file.yaml",
+			expectedCmd:  "config-set",
+			expectedArgs: []string{"data-id", "group", "-f", "/path/to/file.yaml"},
+			description:  "Config set with short file flag",
+		},
+		{
+			name:         "command with home directory path",
+			input:        "skill-get my-skill -o ~/skills",
+			expectedCmd:  "skill-get",
+			expectedArgs: []string{"my-skill", "-o", "~/skills"},
+			description:  "Path with tilde should be treated as single argument",
+		},
+		{
+			name:         "complex command with all options",
+			input:        "skill-get test-skill --version v2 --label latest -o /tmp/output",
+			expectedCmd:  "skill-get",
+			expectedArgs: []string{"test-skill", "--version", "v2", "--label", "latest", "-o", "/tmp/output"},
+			description:  "Complex command with multiple flags and values",
+		},
+		{
+			name:         "command with help flag",
+			input:        "skill-get --help",
+			expectedCmd:  "skill-get",
+			expectedArgs: []string{"--help"},
+			description:  "Help flag should be recognized as boolean",
+		},
+		{
+			name:         "command with h short flag",
+			input:        "skill-get -h",
+			expectedCmd:  "skill-get",
+			expectedArgs: []string{"-h"},
+			description:  "Short help flag should be recognized as boolean",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd, args := parseCommandArgs(tt.input)
+			
+			if cmd != tt.expectedCmd {
+				t.Errorf("parseCommandArgs(%q) cmd = %q, want %q\nTest: %s\nDescription: %s", 
+					tt.input, cmd, tt.expectedCmd, tt.name, tt.description)
+			}
+			
+			if len(args) != len(tt.expectedArgs) {
+				t.Errorf("parseCommandArgs(%q) args length = %d, want %d\nGot:  %v\nWant: %v\nTest: %s\nDescription: %s", 
+					tt.input, len(args), len(tt.expectedArgs), args, tt.expectedArgs, tt.name, tt.description)
+			}
+			
+			for i, arg := range args {
+				if i < len(tt.expectedArgs) && arg != tt.expectedArgs[i] {
+					t.Errorf("parseCommandArgs(%q) args[%d] = %q, want %q\nFull got:  %v\nFull want: %v\nTest: %s\nDescription: %s", 
+						tt.input, i, arg, tt.expectedArgs[i], args, tt.expectedArgs, tt.name, tt.description)
+				}
+			}
+		})
+	}
+}
+
+func TestParseCommandArgsEdgeCases(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		expectedCmd   string
+		expectedArgs  []string
+	}{
+		{
+			name:          "empty input",
+			input:         "",
+			expectedCmd:   "",
+			expectedArgs:  nil,
+		},
+		{
+			name:          "whitespace only",
+			input:         "   ",
+			expectedCmd:   "",
+			expectedArgs:  nil,
+		},
+		{
+			name:         "command only",
+			input:        "skill-list",
+			expectedCmd:  "skill-list",
+			expectedArgs: []string{},
+		},
+		{
+			name:         "multiple spaces between args",
+			input:        "skill-get    my-skill    --label    latest",
+			expectedCmd:  "skill-get",
+			expectedArgs: []string{"my-skill", "--label", "latest"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd, args := parseCommandArgs(tt.input)
+			
+			if cmd != tt.expectedCmd {
+				t.Errorf("parseCommandArgs(%q) cmd = %q, want %q", tt.input, cmd, tt.expectedCmd)
+			}
+			
+			if len(args) != len(tt.expectedArgs) {
+				t.Errorf("parseCommandArgs(%q) args length = %d, want %d", tt.input, len(args), len(tt.expectedArgs))
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Add getPrompt method to show user info in terminal prompt with color coding
- Update readline prompt to use dynamic user-based prompt string
- Display detailed user/auth info on welcome screen based on auth type
- Implement parseCommandArgs to correctly parse commands with flags and values
- Refactor handleCommand to use improved argument parsing logic
- Enhance getSkill to support --version, --label, and -o flags with proper parsing
- Expand output directory path and handle ~ to home directory expansion
- Add success/failure summary for multiple skill downloads
- Similarly refactor getAgentSpec to parse flags and positional arguments
- Add output directory handling and path expansion for agent specs
- Show download progress and summary with counts and failed items list
- Add getAuthTypeDisplay to provide human-readable auth type descriptions