### PR TITLE
feat(agentspec): rename upload command to publish and enhance functio…

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,20 +123,20 @@ nacos-cli agentspec-get spec1 spec2 spec3
 nacos> agentspec-get my-agentspec
 ```
 
-#### Upload AgentSpec
+#### Publish AgentSpec
 
-Upload an agent spec from local directory:
+Publish an agent spec from local directory:
 
 ```bash
-# Upload single agent spec
-nacos-cli agentspec-upload /path/to/agentspec -s 127.0.0.1:8848 -u nacos -p nacos
+# Publish single agent spec
+nacos-cli agentspec-publish /path/to/agentspec -s 127.0.0.1:8848 -u nacos -p nacos
 
-# Upload all agent specs in a directory
-nacos-cli agentspec-upload --all /path/to/agentspecs/folder
+# Publish all agent specs in a directory
+nacos-cli agentspec-publish --all /path/to/agentspecs/folder
 
 # Terminal mode
-nacos> agentspec-upload /path/to/agentspec
-nacos> agentspec-upload --all /path/to/agentspecs
+nacos> agentspec-publish /path/to/agentspec
+nacos> agentspec-publish --all /path/to/agentspecs
 ```
 
 ### Skill Management
@@ -321,7 +321,7 @@ nacos-cli/
 │   ├── sync_skill.go    # skill-sync command
 │   ├── list_agentspec.go   # agentspec-list command
 │   ├── get_agentspec.go    # agentspec-get command
-│   ├── upload_agentspec.go # agentspec-upload command
+│   ├── publish_agentspec.go # agentspec-publish command
 │   ├── list_config.go   # config-list command
 │   ├── get_config.go    # config-get command
 │   └── interactive.go   # Interactive terminal

--- a/cmd/list_agentspec.go
+++ b/cmd/list_agentspec.go
@@ -14,7 +14,6 @@ var (
 	agentSpecListPage   int
 	agentSpecListSize   int
 	agentSpecListName   string
-	agentSpecSearchMode string
 )
 
 var listAgentSpecCmd = &cobra.Command{
@@ -29,7 +28,7 @@ var listAgentSpecCmd = &cobra.Command{
 		agentSpecService := agentspec.NewAgentSpecService(nacosClient)
 
 		// List agent specs
-		specs, totalCount, err := agentSpecService.ListAgentSpecs(agentSpecListName, agentSpecSearchMode, agentSpecListPage, agentSpecListSize)
+		specs, totalCount, err := agentSpecService.ListAgentSpecs(agentSpecListName, "", agentSpecListPage, agentSpecListSize)
 		checkError(err)
 
 		// Display results
@@ -62,6 +61,5 @@ func init() {
 	listAgentSpecCmd.Flags().IntVar(&agentSpecListPage, "page", 1, "Page number (default: 1)")
 	listAgentSpecCmd.Flags().IntVar(&agentSpecListSize, "size", 20, "Page size (default: 20)")
 	listAgentSpecCmd.Flags().StringVar(&agentSpecListName, "name", "", "Filter by agent spec name")
-	listAgentSpecCmd.Flags().StringVar(&agentSpecSearchMode, "search", "", "Search mode: accurate or blur")
 	rootCmd.AddCommand(listAgentSpecCmd)
 }

--- a/cmd/publish_agentspec.go
+++ b/cmd/publish_agentspec.go
@@ -13,13 +13,13 @@ import (
 )
 
 var (
-	agentSpecUploadAll bool
+	agentSpecPublishAll bool
 )
 
-var uploadAgentSpecCmd = &cobra.Command{
-	Use:   "agentspec-upload [agentSpecPath]",
-	Short: "Upload an agent spec to Nacos (upload as ZIP)",
-	Long:  help.AgentSpecUpload.FormatForCLI("nacos-cli"),
+var publishAgentSpecCmd = &cobra.Command{
+	Use:   "agentspec-publish [agentSpecPath]",
+	Short: "Publish an agent spec to Nacos (upload as ZIP)",
+	Long:  help.AgentSpecPublish.FormatForCLI("nacos-cli"),
 	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
@@ -28,50 +28,41 @@ var uploadAgentSpecCmd = &cobra.Command{
 		}
 		specPath := args[0]
 
-		// Create Nacos client
 		nacosClient := mustNewNacosClient()
-
-		// Create agentspec service
 		agentSpecService := agentspec.NewAgentSpecService(nacosClient)
 
-		// Handle batch upload
-		if agentSpecUploadAll {
-			uploadAllAgentSpecs(specPath, agentSpecService)
+		if agentSpecPublishAll {
+			publishAllAgentSpecs(specPath, agentSpecService)
 			return
 		}
 
-		// Single agent spec upload
-		uploadSingleAgentSpec(specPath, agentSpecService)
+		publishSingleAgentSpec(specPath, agentSpecService)
 	},
 }
 
-func uploadSingleAgentSpec(specPath string, agentSpecService *agentspec.AgentSpecService) {
-	// Expand ~ to home directory
+func publishSingleAgentSpec(specPath string, agentSpecService *agentspec.AgentSpecService) {
 	expanded, err := util.ExpandTilde(specPath)
 	checkError(err)
 	specPath = expanded
 
-	// Expand path
 	absPath, err := filepath.Abs(specPath)
 	checkError(err)
 
 	specName := filepath.Base(absPath)
-	fmt.Printf("Uploading agent spec: %s...\n", specName)
+	fmt.Printf("Publishing agent spec: %s...\n", specName)
 
 	err = agentSpecService.UploadAgentSpec(absPath)
 	checkError(err)
 
-	fmt.Printf("Agent spec uploaded successfully!\n")
+	fmt.Printf("Agent spec published successfully!\n")
 	fmt.Printf("  Tip: Use the Nacos console to review and go online, or use 'agentspec-list' to verify.\n")
 }
 
-func uploadAllAgentSpecs(folderPath string, agentSpecService *agentspec.AgentSpecService) {
-	// Expand ~ to home directory
+func publishAllAgentSpecs(folderPath string, agentSpecService *agentspec.AgentSpecService) {
 	expanded, err := util.ExpandTilde(folderPath)
 	checkError(err)
 	folderPath = expanded
 
-	// List subdirectories
 	entries, err := os.ReadDir(folderPath)
 	checkError(err)
 
@@ -81,7 +72,6 @@ func uploadAllAgentSpecs(folderPath string, agentSpecService *agentspec.AgentSpe
 			continue
 		}
 
-		// Check if manifest.json exists
 		manifestPath := filepath.Join(folderPath, entry.Name(), "manifest.json")
 		if _, err := os.Stat(manifestPath); err == nil {
 			specDirs = append(specDirs, entry.Name())
@@ -104,24 +94,23 @@ func uploadAllAgentSpecs(folderPath string, agentSpecService *agentspec.AgentSpe
 
 	for i, specName := range specDirs {
 		fmt.Println(strings.Repeat("=", 80))
-		fmt.Printf("[%d/%d] Uploading agent spec: %s\n", i+1, len(specDirs), specName)
+		fmt.Printf("[%d/%d] Publishing agent spec: %s\n", i+1, len(specDirs), specName)
 		fmt.Println(strings.Repeat("=", 80))
 
 		specPath := filepath.Join(folderPath, specName)
 		err := agentSpecService.UploadAgentSpec(specPath)
 		if err != nil {
-			fmt.Printf("Upload failed: %v\n", err)
+			fmt.Printf("Publish failed: %v\n", err)
 			failedCount++
 		} else {
-			fmt.Printf("Upload successful!\n")
+			fmt.Printf("Publish successful!\n")
 			successCount++
 		}
 		fmt.Println()
 	}
 
-	// Summary
 	fmt.Println(strings.Repeat("=", 80))
-	fmt.Println("Batch Upload Complete")
+	fmt.Println("Batch Publish Complete")
 	fmt.Println(strings.Repeat("=", 80))
 	fmt.Printf("Success: %d\n", successCount)
 	if failedCount > 0 {
@@ -133,6 +122,6 @@ func uploadAllAgentSpecs(folderPath string, agentSpecService *agentspec.AgentSpe
 }
 
 func init() {
-	uploadAgentSpecCmd.Flags().BoolVar(&agentSpecUploadAll, "all", false, "Upload all agent specs in the directory")
-	rootCmd.AddCommand(uploadAgentSpecCmd)
+	publishAgentSpecCmd.Flags().BoolVar(&agentSpecPublishAll, "all", false, "Publish all agent specs in the directory")
+	rootCmd.AddCommand(publishAgentSpecCmd)
 }

--- a/internal/agentspec/agentspec_service.go
+++ b/internal/agentspec/agentspec_service.go
@@ -22,15 +22,19 @@ type AgentSpecService struct {
 	client *client.NacosClient
 }
 
-// AgentSpecListItem represents an agentspec item in the admin list
+// AgentSpecListItem represents an agentspec item in the admin list (AgentSpecSummary in Nacos).
 type AgentSpecListItem struct {
+	NamespaceId      string            `json:"namespaceId,omitempty"`
 	Name             string            `json:"name"`
 	Description      *string           `json:"description"`
 	Enable           bool              `json:"enable"`
 	Labels           map[string]string `json:"labels"`
+	Scope            *string           `json:"scope,omitempty"`
+	BizTags          *string           `json:"bizTags,omitempty"`
 	EditingVersion   *string           `json:"editingVersion"`
 	ReviewingVersion *string           `json:"reviewingVersion"`
 	OnlineCnt        int               `json:"onlineCnt"`
+	DownloadCount    *int64            `json:"downloadCount,omitempty"`
 	UpdateTime       int64             `json:"updateTime"`
 }
 
@@ -47,6 +51,7 @@ type AgentSpec struct {
 	NamespaceId string                        `json:"namespaceId"`
 	Name        string                        `json:"name"`
 	Description string                        `json:"description"`
+	BizTags     string                        `json:"bizTags,omitempty"`
 	Content     string                        `json:"content"` // manifest.json string
 	Resource    map[string]*AgentSpecResource `json:"resource,omitempty"`
 }
@@ -137,6 +142,24 @@ func (s *AgentSpecService) ListAgentSpecs(agentSpecName string, search string, p
 	return listResp.PageItems, listResp.TotalCount, nil
 }
 
+// buildResourceRelativePath matches Nacos AgentSpecOperationServiceImpl.buildResourcePath:
+// if type is blank, use name only; if name already starts with "type/", use name; else "type/name".
+func buildResourceRelativePath(res *AgentSpecResource) string {
+	if res == nil {
+		return ""
+	}
+	t := strings.TrimSpace(res.Type)
+	n := strings.TrimSpace(res.Name)
+	if t == "" {
+		return n
+	}
+	prefix := t + "/"
+	if strings.HasPrefix(n, prefix) {
+		return n
+	}
+	return t + "/" + n
+}
+
 // GetAgentSpec retrieves an agentspec via the Client API and saves it to local directory.
 // Priority for version resolution: label > version > latest.
 func (s *AgentSpecService) GetAgentSpec(name, outputDir string, version, label string) error {
@@ -196,21 +219,19 @@ func (s *AgentSpecService) GetAgentSpec(name, outputDir string, version, label s
 		return fmt.Errorf("failed to create directory: %w", err)
 	}
 
-	// Save resource files
+	// Save resource files (paths aligned with server buildResourcePath)
 	for _, res := range spec.Resource {
 		if res == nil || res.Content == "" {
 			continue
 		}
-		var fileDir string
-		if res.Type != "" {
-			fileDir = filepath.Join(specDir, res.Type)
-		} else {
-			fileDir = specDir
+		rel := buildResourceRelativePath(res)
+		if rel == "" {
+			continue
 		}
-		if err := os.MkdirAll(fileDir, 0755); err != nil {
+		filePath := filepath.Join(specDir, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
 			return fmt.Errorf("failed to create resource directory: %w", err)
 		}
-		filePath := filepath.Join(fileDir, res.Name)
 		// Decode base64 content for binary files
 		var data []byte
 		if enc, ok := res.Metadata["encoding"]; ok && enc == "base64" {
@@ -318,8 +339,11 @@ func (s *AgentSpecService) UploadAgentSpec(agentSpecPath string) error {
 	}
 
 	// Send HTTP request
-	uploadURL := fmt.Sprintf("http://%s/nacos/v3/admin/ai/agentspecs/upload?namespaceId=%s",
-		s.client.ServerAddr, s.client.Namespace)
+	uploadParams := url.Values{}
+	uploadParams.Set("namespaceId", s.client.Namespace)
+	uploadParams.Set("overwrite", "false")
+	uploadURL := fmt.Sprintf("http://%s/nacos/v3/admin/ai/agentspecs/upload?%s",
+		s.client.ServerAddr, uploadParams.Encode())
 	req, err := http.NewRequest("POST", uploadURL, body)
 	if err != nil {
 		return err

--- a/internal/agentspec/agentspec_service_test.go
+++ b/internal/agentspec/agentspec_service_test.go
@@ -5,6 +5,28 @@ import (
 	"testing"
 )
 
+func TestBuildResourceRelativePath(t *testing.T) {
+	cases := []struct {
+		name string
+		res  *AgentSpecResource
+		want string
+	}{
+		{"nil", nil, ""},
+		{"type and basename", &AgentSpecResource{Type: "config", Name: "app.yaml"}, "config/app.yaml"},
+		{"nested type", &AgentSpecResource{Type: "skills/my-skill", Name: "SKILL.md"}, "skills/my-skill/SKILL.md"},
+		{"name already prefixed", &AgentSpecResource{Type: "config", Name: "config/app.yaml"}, "config/app.yaml"},
+		{"no type", &AgentSpecResource{Type: "", Name: "Dockerfile"}, "Dockerfile"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildResourceRelativePath(tc.res)
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestAgentSpecListItem_UnmarshalJSON(t *testing.T) {
 	// Test that nullable fields are handled correctly
 	jsonData := `{

--- a/internal/help/help.go
+++ b/internal/help/help.go
@@ -154,7 +154,6 @@ var (
 		Description: "List all agent specs from Nacos configuration center.",
 		Parameters: []string{
 			"--name string     Filter by agent spec name",
-			"--search string   Search mode: accurate or blur",
 			"--page int        Page number (default: 1)",
 			"--size int        Page size (default: 20)",
 		},
@@ -162,8 +161,8 @@ var (
 			"# List all agent specs",
 			"agentspec-list",
 			"",
-			"# Search by name (blur)",
-			"agentspec-list --name \"worker\" --search blur",
+			"# Search by name",
+			"agentspec-list --name \"worker\"",
 			"",
 			"# With pagination",
 			"agentspec-list --page 2 --size 10",
@@ -197,26 +196,26 @@ var (
 		},
 	}
 
-	AgentSpecUpload = CommandHelp{
-		Command:     "agentspec-upload",
-		Description: "Upload an agent spec to Nacos by uploading it as a ZIP file (creates a draft version).\nReview and go-online operations should be done via the Nacos console.",
+	AgentSpecPublish = CommandHelp{
+		Command:     "agentspec-publish",
+		Description: "Publish an agent spec to Nacos by uploading it as a ZIP file (creates a draft version).\nReview and go-online operations should be done via the Nacos console.",
 		Parameters: []string{
 			"agentSpecPath   Required. Path to the agent spec directory or .zip file",
-			"--all           Upload all agent specs in the specified directory",
+			"--all           Publish all agent specs in the specified directory",
 		},
 		Examples: []string{
-			"# Upload a single agent spec",
-			"agentspec-upload ./my-worker",
+			"# Publish a single agent spec",
+			"agentspec-publish ./my-worker",
 			"",
-			"# Upload a pre-built zip file",
-			"agentspec-upload ./my-worker.zip",
+			"# Publish a pre-built zip file",
+			"agentspec-publish ./my-worker.zip",
 			"",
-			"# Upload all agent specs in a directory",
-			"agentspec-upload --all ./specs-folder",
+			"# Publish all agent specs in a directory",
+			"agentspec-publish --all ./specs-folder",
 			"",
 			"Note:",
 			"  - Agent spec directory must contain manifest.json",
-			"  - After uploading, use the Nacos console to review and go online",
+			"  - After publishing, use the Nacos console to review and go online",
 		},
 	}
 )

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -84,7 +84,7 @@ func completer() *readline.PrefixCompleter {
 			readline.PcItem("--help"),
 			readline.PcItem("-h"),
 		),
-		readline.PcItem("agentspec-upload",
+		readline.PcItem("agentspec-publish",
 			readline.PcItem("--help"),
 			readline.PcItem("-h"),
 			readline.PcItem("--all"),
@@ -278,11 +278,11 @@ func (t *Terminal) handleCommand(input string) {
 		} else {
 			t.getAgentSpec(args)
 		}
-	case "agentspec-upload":
+	case "agentspec-publish":
 		if len(args) > 0 && (args[0] == "--help" || args[0] == "-h") {
-			t.showAgentSpecUploadHelp()
+			t.showAgentSpecPublishHelp()
 		} else {
-			t.uploadAgentSpec(args)
+			t.publishAgentSpec(args)
 		}
 	case "config-list":
 		if len(args) > 0 && (args[0] == "--help" || args[0] == "-h") {
@@ -334,10 +334,10 @@ func (t *Terminal) showHelp() {
 	// AgentSpec Management
 	fmt.Println("\033[1;33mAgentSpec Management\033[0m")
 	fmt.Printf("\033[32m%-20s\033[0m %-40s %-30s\n", "agentspec-list", "List all agent specs", "agentspec-list [options]")
-	fmt.Printf("\033[32m%-20s\033[0m %-40s %-30s\n", "", "Options: --name, --search, --page, --size", "")
+	fmt.Printf("\033[32m%-20s\033[0m %-40s %-30s\n", "", "Options: --name, --page, --size", "")
 	fmt.Printf("\033[32m%-20s\033[0m %-40s %-30s\n", "agentspec-get", "Download an agent spec to ~/.agentspecs", "agentspec-get <name> [--version v1] [--label stable]")
-	fmt.Printf("\033[32m%-20s\033[0m %-40s %-30s\n", "agentspec-upload", "Upload an agent spec from local", "agentspec-upload <path>")
-	fmt.Printf("\033[32m%-20s\033[0m %-40s %-30s\n", "", "Upload all agent specs in directory", "agentspec-upload --all <folder>")
+	fmt.Printf("\033[32m%-20s\033[0m %-40s %-30s\n", "agentspec-publish", "Publish an agent spec from local", "agentspec-publish <path>")
+	fmt.Printf("\033[32m%-20s\033[0m %-40s %-30s\n", "", "Publish all agent specs in directory", "agentspec-publish --all <folder>")
 	fmt.Println()
 
 	// Configuration Management
@@ -998,14 +998,14 @@ func (t *Terminal) showAgentSpecGetHelp() {
 	help.AgentSpecGet.FormatForTerminal()
 }
 
-func (t *Terminal) showAgentSpecUploadHelp() {
-	help.AgentSpecUpload.FormatForTerminal()
+func (t *Terminal) showAgentSpecPublishHelp() {
+	help.AgentSpecPublish.FormatForTerminal()
 }
 
 // listAgentSpecs lists all agent specs
 func (t *Terminal) listAgentSpecs(args []string) {
 	// Parse flags
-	var name, search string
+	var name string
 	var page, size int = 1, 20
 
 	for i := 0; i < len(args); i++ {
@@ -1015,11 +1015,6 @@ func (t *Terminal) listAgentSpecs(args []string) {
 		} else if arg == "--name" && i+1 < len(args) {
 			i++
 			name = args[i]
-		} else if strings.HasPrefix(arg, "--search=") {
-			search = strings.TrimPrefix(arg, "--search=")
-		} else if arg == "--search" && i+1 < len(args) {
-			i++
-			search = args[i]
 		} else if strings.HasPrefix(arg, "--page=") {
 			value := strings.TrimPrefix(arg, "--page=")
 			if value != "" {
@@ -1041,7 +1036,7 @@ func (t *Terminal) listAgentSpecs(args []string) {
 
 	fmt.Print("\033[90mFetching agent specs...\033[0m\r")
 
-	specs, totalCount, err := t.agentSpecService.ListAgentSpecs(name, search, page, size)
+	specs, totalCount, err := t.agentSpecService.ListAgentSpecs(name, "", page, size)
 	if err != nil {
 		fmt.Printf("\033[31mError:\033[0m %v\n", err)
 		return
@@ -1181,10 +1176,10 @@ func (t *Terminal) getAgentSpec(args []string) {
 	}
 }
 
-// uploadAgentSpec uploads an agent spec
-func (t *Terminal) uploadAgentSpec(args []string) {
+// publishAgentSpec publishes an agent spec (mirrors skill-publish).
+func (t *Terminal) publishAgentSpec(args []string) {
 	if len(args) == 0 {
-		fmt.Println("Usage: agentspec-upload <agentSpecPath> or agentspec-upload --all <folder>")
+		fmt.Println("Usage: agentspec-publish <agentSpecPath> or agentspec-publish --all <folder>")
 		return
 	}
 
@@ -1211,14 +1206,14 @@ func (t *Terminal) uploadAgentSpec(args []string) {
 	if allFlagIndex >= 0 {
 		if folderPath == "" {
 			fmt.Println("Error: folder path required for --all flag")
-			fmt.Println("Usage: agentspec-upload --all <folder> or agentspec-upload <folder> --all")
+			fmt.Println("Usage: agentspec-publish --all <folder> or agentspec-publish <folder> --all")
 			return
 		}
-		t.uploadAllAgentSpecs(folderPath)
+		t.publishAllAgentSpecs(folderPath)
 		return
 	}
 
-	// Single agent spec upload
+	// Single agent spec publish
 	specPath := args[0]
 
 	// Expand ~ to home directory
@@ -1238,7 +1233,7 @@ func (t *Terminal) uploadAgentSpec(args []string) {
 		specPath = homeDir
 	}
 
-	fmt.Printf("Uploading agent spec: %s...\n", specPath)
+	fmt.Printf("Publishing agent spec: %s...\n", specPath)
 
 	err := t.agentSpecService.UploadAgentSpec(specPath)
 	if err != nil {
@@ -1246,11 +1241,11 @@ func (t *Terminal) uploadAgentSpec(args []string) {
 		return
 	}
 
-	fmt.Printf("Agent spec uploaded successfully!\n")
+	fmt.Printf("Agent spec published successfully!\n")
 }
 
-// uploadAllAgentSpecs uploads all agent specs in a directory
-func (t *Terminal) uploadAllAgentSpecs(folderPath string) {
+// publishAllAgentSpecs publishes all agent specs in a directory
+func (t *Terminal) publishAllAgentSpecs(folderPath string) {
 	// Expand ~ to home directory
 	if strings.HasPrefix(folderPath, "~/") {
 		homeDir, err := os.UserHomeDir()
@@ -1304,16 +1299,16 @@ func (t *Terminal) uploadAllAgentSpecs(folderPath string) {
 
 	for i, specName := range specDirs {
 		fmt.Println(strings.Repeat("=", 80))
-		fmt.Printf("[%d/%d] Uploading agent spec: %s\n", i+1, len(specDirs), specName)
+		fmt.Printf("[%d/%d] Publishing agent spec: %s\n", i+1, len(specDirs), specName)
 		fmt.Println(strings.Repeat("=", 80))
 
 		specPath := filepath.Join(folderPath, specName)
 		err := t.agentSpecService.UploadAgentSpec(specPath)
 		if err != nil {
-			fmt.Printf("Upload failed: %v\n", err)
+			fmt.Printf("Publish failed: %v\n", err)
 			failedCount++
 		} else {
-			fmt.Printf("Upload successful!\n")
+			fmt.Printf("Publish successful!\n")
 			successCount++
 		}
 		fmt.Println()
@@ -1321,7 +1316,7 @@ func (t *Terminal) uploadAllAgentSpecs(folderPath string) {
 
 	// Summary
 	fmt.Println(strings.Repeat("=", 80))
-	fmt.Println("Batch Upload Complete")
+	fmt.Println("Batch Publish Complete")
 	fmt.Println(strings.Repeat("=", 80))
 	fmt.Printf("Success: %d\n", successCount)
 	if failedCount > 0 {
@@ -1329,7 +1324,7 @@ func (t *Terminal) uploadAllAgentSpecs(folderPath string) {
 	}
 	fmt.Printf("Total: %d\n", len(specDirs))
 	fmt.Println()
-	fmt.Println("Tip: Use 'agentspec-list' to view all uploaded agent specs")
+	fmt.Println("Tip: Use 'agentspec-list' to view all published agent specs")
 }
 
 // truncateDesc truncates description to maxLen and appends ...... if needed


### PR DESCRIPTION
…nality

- Updated the agentspec command from `agentspec-upload` to `agentspec-publish` for clarity and consistency.
- Modified README documentation to reflect the new command name and usage.
- Removed the search mode parameter from the list command for simplification.
- Introduced a new `publish_agentspec.go` file to handle publishing logic for agent specs.
- Added tests for the new functionality and improved resource path handling in the agentspec service.

This change aligns with the overall goal of improving the user experience and command clarity in the Nacos CLI.

Change-Id: I886d1fec623bf2504bbc721c8efaa74cc6cb27f7
Co-developed-by: Cursor <noreply@cursor.com>