### PR TITLE
fix: add SPAS auth headers for skill/agentspec AI resource APIs

### DIFF
--- a/internal/agentspec/agentspec_service.go
+++ b/internal/agentspec/agentspec_service.go
@@ -102,13 +102,9 @@ func (s *AgentSpecService) ListAgentSpecs(agentSpecName string, search string, p
 	listURL := fmt.Sprintf("http://%s/nacos/v3/admin/ai/agentspecs/list?%s",
 		s.client.ServerAddr, params.Encode())
 
-	req, err := http.NewRequest("GET", listURL, nil)
+	req, err := s.client.NewAuthedRequest("GET", listURL, nil)
 	if err != nil {
 		return nil, 0, err
-	}
-
-	if s.client.AccessToken != "" {
-		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", s.client.AccessToken))
 	}
 
 	httpClient := &http.Client{}
@@ -182,12 +178,9 @@ func (s *AgentSpecService) GetAgentSpec(name, outputDir string, version, label s
 	apiURL := fmt.Sprintf("http://%s/nacos/v3/client/ai/agentspecs?%s",
 		s.client.ServerAddr, params.Encode())
 
-	req, err := http.NewRequest("GET", apiURL, nil)
+	req, err := s.client.NewAuthedRequest("GET", apiURL, nil)
 	if err != nil {
 		return fmt.Errorf("failed to build request: %w", err)
-	}
-	if s.client.AccessToken != "" {
-		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", s.client.AccessToken))
 	}
 
 	httpClient := &http.Client{}
@@ -353,16 +346,12 @@ func (s *AgentSpecService) UploadAgentSpec(agentSpecPath string) error {
 	uploadParams.Set("overwrite", "false")
 	uploadURL := fmt.Sprintf("http://%s/nacos/v3/admin/ai/agentspecs/upload?%s",
 		s.client.ServerAddr, uploadParams.Encode())
-	req, err := http.NewRequest("POST", uploadURL, body)
+	req, err := s.client.NewAuthedRequest("POST", uploadURL, body)
 	if err != nil {
 		return err
 	}
 
 	req.Header.Set("Content-Type", writer.FormDataContentType())
-
-	if s.client.AccessToken != "" {
-		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", s.client.AccessToken))
-	}
 
 	httpClient := &http.Client{}
 	resp, err := httpClient.Do(req)

--- a/internal/client/nacos_client.go
+++ b/internal/client/nacos_client.go
@@ -6,6 +6,8 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
@@ -280,6 +282,36 @@ func spasSign(signData, secretKey string) string {
 	mac := hmac.New(sha1.New, []byte(secretKey))
 	mac.Write([]byte(signData))
 	return base64.StdEncoding.EncodeToString(mac.Sum(nil))
+}
+
+// aiResourceGroup is the fixed group used for signing AI resource requests (skill/agentspec).
+const aiResourceGroup = "DEFAULT_GROUP"
+
+// NewAuthedRequest creates an *http.Request with authentication headers already applied.
+// It sets the Bearer token header for nacos/token auth and SPAS headers for aliyun auth.
+// AI resource APIs (skill, agentspec) use namespaceId as tenant and DEFAULT_GROUP as group
+// for SPAS signature calculation.
+func (c *NacosClient) NewAuthedRequest(method, url string, body io.Reader) (*http.Request, error) {
+	req, err := http.NewRequest(method, url, body)
+	if err != nil {
+		return nil, err
+	}
+	// Bearer token (nacos / token auth)
+	if c.AccessToken != "" {
+		req.Header.Set("Authorization", "Bearer "+c.AccessToken)
+	}
+	// SPAS headers (aliyun auth): tenant=namespaceId, group=DEFAULT_GROUP
+	if c.AuthType == AuthTypeAliyun && c.AccessKey != "" && c.SecretKey != "" {
+		ts := strconv.FormatInt(time.Now().UnixMilli(), 10)
+		tenant := c.Namespace
+		if tenant == "public" {
+			tenant = ""
+		}
+		req.Header.Set("timeStamp", ts)
+		req.Header.Set("Spas-AccessKey", c.AccessKey)
+		req.Header.Set("Spas-Signature", spasSign(getSignData(tenant, aiResourceGroup, ts), c.SecretKey))
+	}
+	return req, nil
 }
 
 // setSpasHeaders sets Aliyun authentication headers for SPAS signature

--- a/internal/skill/skill_service.go
+++ b/internal/skill/skill_service.go
@@ -73,13 +73,9 @@ func (s *SkillService) ListSkills(skillName string, pageNo, pageSize int) ([]Ski
 	listURL := fmt.Sprintf("http://%s/nacos/v3/admin/ai/skills/list?%s",
 		s.client.ServerAddr, params.Encode())
 
-	req, err := http.NewRequest("GET", listURL, nil)
+	req, err := s.client.NewAuthedRequest("GET", listURL, nil)
 	if err != nil {
 		return nil, 0, err
-	}
-
-	if s.client.AccessToken != "" {
-		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", s.client.AccessToken))
 	}
 
 	httpClient := &http.Client{}
@@ -136,12 +132,9 @@ func (s *SkillService) GetSkill(skillName, outputDir string, version, label stri
 	apiURL := fmt.Sprintf("http://%s/nacos/v3/client/ai/skills?%s",
 		s.client.ServerAddr, params.Encode())
 
-	req, err := http.NewRequest("GET", apiURL, nil)
+	req, err := s.client.NewAuthedRequest("GET", apiURL, nil)
 	if err != nil {
 		return fmt.Errorf("failed to build request: %w", err)
-	}
-	if s.client.AccessToken != "" {
-		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", s.client.AccessToken))
 	}
 
 	httpClient := &http.Client{}
@@ -289,16 +282,12 @@ func (s *SkillService) UploadSkill(skillPath string) error {
 	// Send HTTP request
 	uploadURL := fmt.Sprintf("http://%s/nacos/v3/admin/ai/skills/upload?namespaceId=%s",
 		s.client.ServerAddr, s.client.Namespace)
-	req, err := http.NewRequest("POST", uploadURL, body)
+	req, err := s.client.NewAuthedRequest("POST", uploadURL, body)
 	if err != nil {
 		return err
 	}
 
 	req.Header.Set("Content-Type", writer.FormDataContentType())
-
-	if s.client.AccessToken != "" {
-		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", s.client.AccessToken))
-	}
 
 	httpClient := &http.Client{}
 	resp, err := httpClient.Do(req)


### PR DESCRIPTION
Aliyun auth (AK/SK) was silently ignored for all skill and agentspec API calls because those services used raw http.NewRequest instead of the NacosClient's resty-based request builder that calls setSpasHeaders.

Changes:
- Add NacosClient.NewAuthedRequest() that injects both Bearer token (nacos/token auth) and SPAS headers (aliyun auth) into a standard *http.Request. AI resources use namespaceId as tenant and DEFAULT_GROUP as the fixed group for signature.
- Replace all http.NewRequest usages in skill_service.go and agentspec_service.go with NewAuthedRequest.