### PR TITLE
[codex] Split skill publish and submit

### DIFF
--- a/cmd/publish_skill.go
+++ b/cmd/publish_skill.go
@@ -59,11 +59,11 @@ func publishSingleSkill(skillPath string, skillService *skill.SkillService) {
 	skillName := filepath.Base(absPath)
 	fmt.Printf("Publishing skill: %s...\n", skillName)
 
-	err = skillService.PublishSkill(absPath)
+	err = skillService.UploadSkill(absPath)
 	checkError(err)
 
-	fmt.Printf("Skill published and submitted successfully!\n")
-	fmt.Printf("  Tip: Auto-publish after review depends on server configuration. Use 'skill-list' to verify.\n")
+	fmt.Printf("Skill draft published successfully!\n")
+	fmt.Printf("  Tip: Use 'skill-submit %s' to submit the draft for review.\n", skillName)
 }
 
 func publishAllSkills(folderPath string, skillService *skill.SkillService) {
@@ -111,7 +111,7 @@ func publishAllSkills(folderPath string, skillService *skill.SkillService) {
 		fmt.Println(strings.Repeat("=", 80))
 
 		skillPath := filepath.Join(folderPath, skillName)
-		err := skillService.PublishSkill(skillPath)
+		err := skillService.UploadSkill(skillPath)
 		if err != nil {
 			fmt.Printf("Publish failed: %v\n", err)
 			failedCount++
@@ -132,7 +132,7 @@ func publishAllSkills(folderPath string, skillService *skill.SkillService) {
 	}
 	fmt.Printf("Total: %d\n", len(skillDirs))
 	fmt.Println()
-	fmt.Println("Tip: Auto-publish after review depends on server configuration. Use 'skill-list' to verify.")
+	fmt.Println("Tip: Use 'skill-submit <skillName>' to submit a draft for review.")
 }
 
 func init() {

--- a/cmd/publish_skill.go
+++ b/cmd/publish_skill.go
@@ -59,11 +59,11 @@ func publishSingleSkill(skillPath string, skillService *skill.SkillService) {
 	skillName := filepath.Base(absPath)
 	fmt.Printf("Publishing skill: %s...\n", skillName)
 
-	err = skillService.UploadSkill(absPath)
+	err = skillService.PublishSkill(absPath)
 	checkError(err)
 
-	fmt.Printf("Skill published successfully!\n")
-	fmt.Printf("  Tip: Use the Nacos console to review and go online, or use 'skill-list' to verify.\n")
+	fmt.Printf("Skill published and submitted successfully!\n")
+	fmt.Printf("  Tip: Auto-publish after review depends on server configuration. Use 'skill-list' to verify.\n")
 }
 
 func publishAllSkills(folderPath string, skillService *skill.SkillService) {
@@ -111,7 +111,7 @@ func publishAllSkills(folderPath string, skillService *skill.SkillService) {
 		fmt.Println(strings.Repeat("=", 80))
 
 		skillPath := filepath.Join(folderPath, skillName)
-		err := skillService.UploadSkill(skillPath)
+		err := skillService.PublishSkill(skillPath)
 		if err != nil {
 			fmt.Printf("Publish failed: %v\n", err)
 			failedCount++
@@ -132,7 +132,7 @@ func publishAllSkills(folderPath string, skillService *skill.SkillService) {
 	}
 	fmt.Printf("Total: %d\n", len(skillDirs))
 	fmt.Println()
-	fmt.Println("Tip: Use the Nacos console to review and go online, or use 'skill-list' to verify.")
+	fmt.Println("Tip: Auto-publish after review depends on server configuration. Use 'skill-list' to verify.")
 }
 
 func init() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -158,6 +158,10 @@ Examples:
 // Called from main.go with values injected via ldflags.
 func SetVersionInfo(version, commit, date string) {
 	rootCmd.Version = fmt.Sprintf("%s (commit: %s, built: %s)", version, commit, date)
+	rootCmd.InitDefaultVersionFlag()
+	if flag := rootCmd.Flags().Lookup("version"); flag != nil {
+		flag.Shorthand = "v"
+	}
 }
 
 // Execute runs the root command

--- a/cmd/submit_skill.go
+++ b/cmd/submit_skill.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/nacos-group/nacos-cli/internal/help"
+	"github.com/nacos-group/nacos-cli/internal/skill"
+	"github.com/spf13/cobra"
+)
+
+var skillSubmitVersion string
+
+var submitSkillCmd = &cobra.Command{
+	Use:   "skill-submit [skillName]",
+	Short: "Submit a skill draft for review",
+	Long:  help.SkillSubmit.FormatForCLI("nacos-cli"),
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		nacosClient := mustNewNacosClient()
+		skillService := skill.NewSkillService(nacosClient)
+
+		skillName := args[0]
+		fmt.Printf("Submitting skill draft: %s...\n", skillName)
+		if err := skillService.SubmitSkill(skillName, skillSubmitVersion); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: failed to submit skill '%s': %v\n", skillName, err)
+			os.Exit(1)
+		}
+		fmt.Printf("Skill submitted successfully!\n")
+		fmt.Printf("  Tip: Auto-publish after review depends on server configuration. Use 'skill-list' to verify.\n")
+	},
+}
+
+func init() {
+	submitSkillCmd.Flags().StringVar(&skillSubmitVersion, "version", "", "Specific draft version to submit")
+	rootCmd.AddCommand(submitSkillCmd)
+}

--- a/internal/help/help.go
+++ b/internal/help/help.go
@@ -64,7 +64,7 @@ var (
 
 	SkillPublish = CommandHelp{
 		Command:     "skill-publish",
-		Description: "Publish a skill to Nacos by uploading it as a ZIP file (creates a draft version).\nReview and go-online operations should be done via the Nacos console.",
+		Description: "Publish a skill to Nacos by uploading it as a ZIP file, then submit the draft for review.\nAuto-publish after review depends on server configuration.",
 		Parameters: []string{
 			"skillPath       Required. Path to the skill directory",
 			"--all           Publish all skills in the specified directory",
@@ -78,7 +78,7 @@ var (
 			"",
 			"Note:",
 			"  - Skill directory must contain SKILL.md",
-			"  - After publishing, use the Nacos console to review and go online",
+			"  - After publishing, the draft is submitted for review automatically",
 		},
 	}
 

--- a/internal/help/help.go
+++ b/internal/help/help.go
@@ -64,7 +64,7 @@ var (
 
 	SkillPublish = CommandHelp{
 		Command:     "skill-publish",
-		Description: "Publish a skill to Nacos by uploading it as a ZIP file, then submit the draft for review.\nAuto-publish after review depends on server configuration.",
+		Description: "Publish a skill to Nacos by uploading it as a ZIP file (creates a draft version).",
 		Parameters: []string{
 			"skillPath       Required. Path to the skill directory",
 			"--all           Publish all skills in the specified directory",
@@ -78,7 +78,27 @@ var (
 			"",
 			"Note:",
 			"  - Skill directory must contain SKILL.md",
-			"  - After publishing, the draft is submitted for review automatically",
+			"  - After publishing, use skill-submit to submit the draft for review",
+		},
+	}
+
+	SkillSubmit = CommandHelp{
+		Command:     "skill-submit",
+		Description: "Submit a skill draft version for review.",
+		Parameters: []string{
+			"skillName       Required. Skill name to submit",
+			"--version       Optional. Specific draft version to submit",
+		},
+		Examples: []string{
+			"# Submit the current draft",
+			"skill-submit my-skill",
+			"",
+			"# Submit a specific draft version",
+			"skill-submit my-skill --version 1.0.0",
+			"",
+			"Note:",
+			"  - If --version is omitted, the server submits the current editingVersion",
+			"  - Auto-publish after review depends on server configuration",
 		},
 	}
 

--- a/internal/skill/skill_service.go
+++ b/internal/skill/skill_service.go
@@ -304,8 +304,8 @@ func (s *SkillService) UploadSkill(skillPath string) error {
 	return nil
 }
 
-// SubmitSkill submits the current draft skill version for review.
-func (s *SkillService) SubmitSkill(skillName string) error {
+// SubmitSkill submits a draft skill version for review.
+func (s *SkillService) SubmitSkill(skillName, version string) error {
 	if err := s.client.EnsureTokenValid(); err != nil {
 		return err
 	}
@@ -313,6 +313,9 @@ func (s *SkillService) SubmitSkill(skillName string) error {
 	params := url.Values{}
 	params.Set("namespaceId", s.client.Namespace)
 	params.Set("skillName", skillName)
+	if version != "" {
+		params.Set("version", version)
+	}
 
 	submitURL := fmt.Sprintf("http://%s/nacos/v3/admin/ai/skills/submit?%s",
 		s.client.ServerAddr, params.Encode())
@@ -346,19 +349,6 @@ func (s *SkillService) SubmitSkill(skillName string) error {
 	}
 
 	return nil
-}
-
-// PublishSkill uploads a skill and submits the draft for review.
-func (s *SkillService) PublishSkill(skillPath string) error {
-	if err := s.UploadSkill(skillPath); err != nil {
-		return err
-	}
-
-	skillName := filepath.Base(skillPath)
-	if strings.HasSuffix(strings.ToLower(skillName), ".zip") {
-		skillName = strings.TrimSuffix(skillName, filepath.Ext(skillName))
-	}
-	return s.SubmitSkill(skillName)
 }
 
 // ParseSkillMD parses SKILL.md file

--- a/internal/skill/skill_service.go
+++ b/internal/skill/skill_service.go
@@ -304,6 +304,63 @@ func (s *SkillService) UploadSkill(skillPath string) error {
 	return nil
 }
 
+// SubmitSkill submits the current draft skill version for review.
+func (s *SkillService) SubmitSkill(skillName string) error {
+	if err := s.client.EnsureTokenValid(); err != nil {
+		return err
+	}
+
+	params := url.Values{}
+	params.Set("namespaceId", s.client.Namespace)
+	params.Set("skillName", skillName)
+
+	submitURL := fmt.Sprintf("http://%s/nacos/v3/admin/ai/skills/submit?%s",
+		s.client.ServerAddr, params.Encode())
+	req, err := s.client.NewAuthedRequest("POST", submitURL, nil)
+	if err != nil {
+		return err
+	}
+
+	httpClient := &http.Client{}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("submit failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read submit response failed: %w", err)
+	}
+
+	if resp.StatusCode != 200 {
+		return client.ParseHTTPError(resp.StatusCode, respBody, "submit skill")
+	}
+
+	var v3Resp V3Response
+	if err := json.Unmarshal(respBody, &v3Resp); err != nil {
+		return fmt.Errorf("parse submit response failed: %w", err)
+	}
+	if v3Resp.Code != 0 {
+		return fmt.Errorf("submit skill failed: code=%d, message=%s", v3Resp.Code, v3Resp.Message)
+	}
+
+	return nil
+}
+
+// PublishSkill uploads a skill and submits the draft for review.
+func (s *SkillService) PublishSkill(skillPath string) error {
+	if err := s.UploadSkill(skillPath); err != nil {
+		return err
+	}
+
+	skillName := filepath.Base(skillPath)
+	if strings.HasSuffix(strings.ToLower(skillName), ".zip") {
+		skillName = strings.TrimSuffix(skillName, filepath.Ext(skillName))
+	}
+	return s.SubmitSkill(skillName)
+}
+
 // ParseSkillMD parses SKILL.md file
 func (s *SkillService) ParseSkillMD(mdPath string) (*SkillInfo, error) {
 	content, err := os.ReadFile(mdPath)
@@ -338,4 +395,3 @@ func (s *SkillService) ParseSkillMD(mdPath string) (*SkillInfo, error) {
 
 	return &skillInfo, nil
 }
-

--- a/internal/skill/skill_service_test.go
+++ b/internal/skill/skill_service_test.go
@@ -12,9 +12,8 @@ import (
 	"github.com/nacos-group/nacos-cli/internal/client"
 )
 
-func TestPublishSkillUploadsThenSubmits(t *testing.T) {
+func TestUploadSkillOnlyUploadsDraft(t *testing.T) {
 	var uploadCalled bool
-	var submitCalled bool
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -46,17 +45,7 @@ func TestPublishSkillUploadsThenSubmits(t *testing.T) {
 			}
 			w.WriteHeader(http.StatusOK)
 		case "/nacos/v3/admin/ai/skills/submit":
-			submitCalled = true
-			if r.Method != http.MethodPost {
-				t.Fatalf("submit method = %s, want POST", r.Method)
-			}
-			if got := r.URL.Query().Get("namespaceId"); got != "test-ns" {
-				t.Fatalf("submit namespaceId = %s, want test-ns", got)
-			}
-			if got := r.URL.Query().Get("skillName"); got != "demo-skill" {
-				t.Fatalf("submit skillName = %s, want demo-skill", got)
-			}
-			_ = json.NewEncoder(w).Encode(V3Response{Code: 0, Message: "success"})
+			t.Fatal("upload should not submit skill draft")
 		default:
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
@@ -76,11 +65,45 @@ func TestPublishSkillUploadsThenSubmits(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := NewSkillService(nacosClient).PublishSkill(skillDir); err != nil {
+	if err := NewSkillService(nacosClient).UploadSkill(skillDir); err != nil {
 		t.Fatal(err)
 	}
 	if !uploadCalled {
 		t.Fatal("upload was not called")
+	}
+}
+
+func TestSubmitSkillSendsFormParams(t *testing.T) {
+	var submitCalled bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/nacos/v3/admin/ai/skills/submit" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		submitCalled = true
+		if r.Method != http.MethodPost {
+			t.Fatalf("submit method = %s, want POST", r.Method)
+		}
+		if got := r.URL.Query().Get("namespaceId"); got != "test-ns" {
+			t.Fatalf("submit namespaceId = %s, want test-ns", got)
+		}
+		if got := r.URL.Query().Get("skillName"); got != "demo-skill" {
+			t.Fatalf("submit skillName = %s, want demo-skill", got)
+		}
+		if got := r.URL.Query().Get("version"); got != "1.0.0" {
+			t.Fatalf("submit version = %s, want 1.0.0", got)
+		}
+		_ = json.NewEncoder(w).Encode(V3Response{Code: 0, Message: "success"})
+	}))
+	defer server.Close()
+
+	nacosClient, err := client.NewNacosClient(strings.TrimPrefix(server.URL, "http://"), "test-ns", client.AuthTypeToken, "", "", "", "", "token")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := NewSkillService(nacosClient).SubmitSkill("demo-skill", "1.0.0"); err != nil {
+		t.Fatal(err)
 	}
 	if !submitCalled {
 		t.Fatal("submit was not called")

--- a/internal/skill/skill_service_test.go
+++ b/internal/skill/skill_service_test.go
@@ -1,0 +1,88 @@
+package skill
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/nacos-group/nacos-cli/internal/client"
+)
+
+func TestPublishSkillUploadsThenSubmits(t *testing.T) {
+	var uploadCalled bool
+	var submitCalled bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/nacos/v3/admin/ai/skills/upload":
+			uploadCalled = true
+			if r.Method != http.MethodPost {
+				t.Fatalf("upload method = %s, want POST", r.Method)
+			}
+			if got := r.URL.Query().Get("namespaceId"); got != "test-ns" {
+				t.Fatalf("upload namespaceId = %s, want test-ns", got)
+			}
+			if err := r.ParseMultipartForm(1 << 20); err != nil {
+				t.Fatalf("parse multipart upload: %v", err)
+			}
+			file, header, err := r.FormFile("file")
+			if err != nil {
+				t.Fatalf("read uploaded file: %v", err)
+			}
+			defer file.Close()
+			if header.Filename != "demo-skill.zip" {
+				t.Fatalf("uploaded filename = %s, want demo-skill.zip", header.Filename)
+			}
+			data, err := io.ReadAll(file)
+			if err != nil {
+				t.Fatalf("read upload body: %v", err)
+			}
+			if !strings.Contains(string(data), "SKILL.md") {
+				t.Fatalf("uploaded zip does not contain SKILL.md")
+			}
+			w.WriteHeader(http.StatusOK)
+		case "/nacos/v3/admin/ai/skills/submit":
+			submitCalled = true
+			if r.Method != http.MethodPost {
+				t.Fatalf("submit method = %s, want POST", r.Method)
+			}
+			if got := r.URL.Query().Get("namespaceId"); got != "test-ns" {
+				t.Fatalf("submit namespaceId = %s, want test-ns", got)
+			}
+			if got := r.URL.Query().Get("skillName"); got != "demo-skill" {
+				t.Fatalf("submit skillName = %s, want demo-skill", got)
+			}
+			_ = json.NewEncoder(w).Encode(V3Response{Code: 0, Message: "success"})
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	skillDir := t.TempDir() + "/demo-skill"
+	if err := os.Mkdir(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(skillDir+"/SKILL.md", []byte("# Demo Skill\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	nacosClient, err := client.NewNacosClient(strings.TrimPrefix(server.URL, "http://"), "test-ns", client.AuthTypeToken, "", "", "", "", "token")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := NewSkillService(nacosClient).PublishSkill(skillDir); err != nil {
+		t.Fatal(err)
+	}
+	if !uploadCalled {
+		t.Fatal("upload was not called")
+	}
+	if !submitCalled {
+		t.Fatal("submit was not called")
+	}
+}

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -188,6 +188,7 @@ func (t *Terminal) printWelcome() {
 // For example: "skill-get my-skill --label latest -o /path" should recognize:
 //   - skill name: my-skill
 //   - flags: --label latest, -o /path
+//
 // This prevents flags and their values from being treated as additional skill names
 func parseCommandArgs(input string) (cmd string, args []string) {
 	parts := strings.Fields(input)
@@ -201,7 +202,7 @@ func parseCommandArgs(input string) (cmd string, args []string) {
 	// Parse remaining parts, handling flags properly
 	for i := 1; i < len(parts); i++ {
 		arg := parts[i]
-		
+
 		// Check if this is a flag
 		if strings.HasPrefix(arg, "-") {
 			args = append(args, arg)
@@ -211,7 +212,7 @@ func parseCommandArgs(input string) (cmd string, args []string) {
 				"--help": true, "-h": true,
 				"--all": true,
 			}
-			
+
 			// If it's a long flag (--flag), check if value is separate
 			if strings.HasPrefix(arg, "--") && !strings.Contains(arg, "=") {
 				if !booleanFlags[arg] && i+1 < len(parts) && !strings.HasPrefix(parts[i+1], "-") {
@@ -515,7 +516,7 @@ func (t *Terminal) getSkill(args []string) {
 
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
-		
+
 		if arg == "--version" && i+1 < len(args) {
 			i++
 			version = args[i]
@@ -607,10 +608,10 @@ func (t *Terminal) getSkill(args []string) {
 	}
 }
 
-// uploadSkill uploads a skill
+// uploadSkill publishes a skill
 func (t *Terminal) uploadSkill(args []string) {
 	if len(args) == 0 {
-		fmt.Println("Usage: skill-upload <skillPath> or skill-upload --all <folder>")
+		fmt.Println("Usage: skill-publish <skillPath> or skill-publish --all <folder>")
 		return
 	}
 
@@ -638,7 +639,7 @@ func (t *Terminal) uploadSkill(args []string) {
 	if allFlagIndex >= 0 {
 		if folderPath == "" {
 			fmt.Println("Error: folder path required for --all flag")
-			fmt.Println("Usage: skill-upload --all <folder> or skill-upload <folder> --all")
+			fmt.Println("Usage: skill-publish --all <folder> or skill-publish <folder> --all")
 			return
 		}
 		t.uploadAllSkills(folderPath)
@@ -665,18 +666,18 @@ func (t *Terminal) uploadSkill(args []string) {
 		skillPath = homeDir
 	}
 
-	fmt.Printf("Uploading skill: %s...\n", skillPath)
+	fmt.Printf("Publishing skill: %s...\n", skillPath)
 
-	err := t.skillService.UploadSkill(skillPath)
+	err := t.skillService.PublishSkill(skillPath)
 	if err != nil {
 		fmt.Printf("Error: %v\n", err)
 		return
 	}
 
-	fmt.Printf("Skill uploaded successfully!\n")
+	fmt.Printf("Skill published and submitted successfully!\n")
 }
 
-// uploadAllSkills uploads all skills in a directory
+// uploadAllSkills publishes all skills in a directory
 func (t *Terminal) uploadAllSkills(folderPath string) {
 	// Expand ~ to home directory
 	if strings.HasPrefix(folderPath, "~/") {
@@ -731,16 +732,16 @@ func (t *Terminal) uploadAllSkills(folderPath string) {
 
 	for i, skillName := range skillDirs {
 		fmt.Println(strings.Repeat("=", 80))
-		fmt.Printf("[%d/%d] Uploading skill: %s\n", i+1, len(skillDirs), skillName)
+		fmt.Printf("[%d/%d] Publishing skill: %s\n", i+1, len(skillDirs), skillName)
 		fmt.Println(strings.Repeat("=", 80))
 
 		skillPath := filepath.Join(folderPath, skillName)
-		err := t.skillService.UploadSkill(skillPath)
+		err := t.skillService.PublishSkill(skillPath)
 		if err != nil {
-			fmt.Printf("Upload failed: %v\n", err)
+			fmt.Printf("Publish failed: %v\n", err)
 			failedCount++
 		} else {
-			fmt.Printf("Upload successful!\n")
+			fmt.Printf("Publish successful!\n")
 			successCount++
 		}
 		fmt.Println()
@@ -748,7 +749,7 @@ func (t *Terminal) uploadAllSkills(folderPath string) {
 
 	// Summary
 	fmt.Println(strings.Repeat("=", 80))
-	fmt.Println("Batch Upload Complete")
+	fmt.Println("Batch Publish Complete")
 	fmt.Println(strings.Repeat("=", 80))
 	fmt.Printf("Success: %d\n", successCount)
 	if failedCount > 0 {
@@ -756,7 +757,7 @@ func (t *Terminal) uploadAllSkills(folderPath string) {
 	}
 	fmt.Printf("Total: %d\n", len(skillDirs))
 	fmt.Println()
-	fmt.Println("Tip: Use 'skill-list' to view all uploaded skills")
+	fmt.Println("Tip: Auto-publish after review depends on server configuration. Use 'skill-list' to verify.")
 }
 
 // listConfigs lists all configurations
@@ -1084,7 +1085,7 @@ func (t *Terminal) getAgentSpec(args []string) {
 
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
-		
+
 		if arg == "--version" && i+1 < len(args) {
 			i++
 			version = args[i]

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -76,6 +76,11 @@ func completer() *readline.PrefixCompleter {
 			readline.PcItem("-h"),
 			readline.PcItem("--all"),
 		),
+		readline.PcItem("skill-submit",
+			readline.PcItem("--help"),
+			readline.PcItem("-h"),
+			readline.PcItem("--version"),
+		),
 		readline.PcItem("agentspec-list",
 			readline.PcItem("--help"),
 			readline.PcItem("-h"),
@@ -264,6 +269,12 @@ func (t *Terminal) handleCommand(input string) {
 		} else {
 			t.uploadSkill(args)
 		}
+	case "skill-submit":
+		if len(args) > 0 && (args[0] == "--help" || args[0] == "-h") {
+			t.showSkillSubmitHelp()
+		} else {
+			t.submitSkill(args)
+		}
 	case "skill-sync":
 		fmt.Println("\033[33mskill-sync has been removed.\033[0m")
 		fmt.Println("\033[90mUse 'skill-get' to download skills.\033[0m")
@@ -330,6 +341,7 @@ func (t *Terminal) showHelp() {
 	fmt.Printf("\033[32m%-20s\033[0m %-40s %-30s\n", "skill-get", "Download a skill to ~/.skills", "skill-get <name> [--version v1] [--label stable]")
 	fmt.Printf("\033[32m%-20s\033[0m %-40s %-30s\n", "skill-publish", "Publish a skill from local", "skill-publish <path>")
 	fmt.Printf("\033[32m%-20s\033[0m %-40s %-30s\n", "", "Publish all skills in directory", "skill-publish --all <folder>")
+	fmt.Printf("\033[32m%-20s\033[0m %-40s %-30s\n", "skill-submit", "Submit a skill draft for review", "skill-submit <name> [--version v1]")
 	fmt.Println()
 
 	// AgentSpec Management
@@ -608,7 +620,7 @@ func (t *Terminal) getSkill(args []string) {
 	}
 }
 
-// uploadSkill publishes a skill
+// uploadSkill publishes a skill draft
 func (t *Terminal) uploadSkill(args []string) {
 	if len(args) == 0 {
 		fmt.Println("Usage: skill-publish <skillPath> or skill-publish --all <folder>")
@@ -668,16 +680,17 @@ func (t *Terminal) uploadSkill(args []string) {
 
 	fmt.Printf("Publishing skill: %s...\n", skillPath)
 
-	err := t.skillService.PublishSkill(skillPath)
+	err := t.skillService.UploadSkill(skillPath)
 	if err != nil {
 		fmt.Printf("Error: %v\n", err)
 		return
 	}
 
-	fmt.Printf("Skill published and submitted successfully!\n")
+	fmt.Printf("Skill draft published successfully!\n")
+	fmt.Printf("Tip: Use 'skill-submit %s' to submit the draft for review.\n", filepath.Base(skillPath))
 }
 
-// uploadAllSkills publishes all skills in a directory
+// uploadAllSkills publishes all skill drafts in a directory
 func (t *Terminal) uploadAllSkills(folderPath string) {
 	// Expand ~ to home directory
 	if strings.HasPrefix(folderPath, "~/") {
@@ -736,7 +749,7 @@ func (t *Terminal) uploadAllSkills(folderPath string) {
 		fmt.Println(strings.Repeat("=", 80))
 
 		skillPath := filepath.Join(folderPath, skillName)
-		err := t.skillService.PublishSkill(skillPath)
+		err := t.skillService.UploadSkill(skillPath)
 		if err != nil {
 			fmt.Printf("Publish failed: %v\n", err)
 			failedCount++
@@ -757,6 +770,35 @@ func (t *Terminal) uploadAllSkills(folderPath string) {
 	}
 	fmt.Printf("Total: %d\n", len(skillDirs))
 	fmt.Println()
+	fmt.Println("Tip: Use 'skill-submit <skillName>' to submit a draft for review.")
+}
+
+// submitSkill submits a skill draft for review
+func (t *Terminal) submitSkill(args []string) {
+	if len(args) == 0 {
+		fmt.Println("Usage: skill-submit <skillName> [--version <version>]")
+		return
+	}
+
+	skillName := args[0]
+	version := ""
+	for i := 1; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--version" && i+1 < len(args) {
+			i++
+			version = args[i]
+		} else if strings.HasPrefix(arg, "--version=") {
+			version = strings.TrimPrefix(arg, "--version=")
+		}
+	}
+
+	fmt.Printf("Submitting skill draft: %s...\n", skillName)
+	if err := t.skillService.SubmitSkill(skillName, version); err != nil {
+		fmt.Printf("Error: %v\n", err)
+		return
+	}
+
+	fmt.Printf("Skill submitted successfully!\n")
 	fmt.Println("Tip: Auto-publish after review depends on server configuration. Use 'skill-list' to verify.")
 }
 
@@ -970,6 +1012,10 @@ func (t *Terminal) showSkillGetHelp() {
 
 func (t *Terminal) showSkillPublishHelp() {
 	help.SkillPublish.FormatForTerminal()
+}
+
+func (t *Terminal) showSkillSubmitHelp() {
+	help.SkillSubmit.FormatForTerminal()
 }
 
 func (t *Terminal) showConfigListHelp() {


### PR DESCRIPTION
## Summary

- Keep `skill-publish` focused on uploading a skill ZIP and creating a draft version.
- Add `skill-submit <skillName> [--version]` to submit a draft for review via `POST /nacos/v3/admin/ai/skills/submit`.
- Keep submit integration Spring form-compatible by sending `namespaceId`, `skillName`, and optional `version` as query parameters.
- Add `-v` as shorthand for the existing `--version` flag for checking the nacos-cli build version.
- Update CLI, interactive terminal help, and tests for the split publish/submit flow.

## Validation

- `go test ./...`
- `go run . skill-publish --help`
- `go run . skill-submit --help`
- `go run . -v`
