### PR TITLE
feat(cli): support Nacos environment configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,10 +420,20 @@ namespace: ""
 Configuration values are applied in the following priority order:
 1. **Command line arguments** (highest priority)
 2. **Configuration file**
-3. **Default values** (lowest priority)
+3. **Environment variables**
+4. **Default values** (lowest priority)
+
+Supported environment variables:
+
+```bash
+export NACOS_HOST=127.0.0.1
+export NACOS_PORT=8848
+export NACOS_NAMESPACE=xxx
+```
 
 For example:
 - `nacos-cli --config ./local.conf --host 10.0.0.1` - Uses `10.0.0.1` from command line, other values from config file
+- `NACOS_HOST=127.0.0.1 NACOS_PORT=8848 NACOS_NAMESPACE=xxx nacos-cli skill-list` - Uses environment variables when command line and config file values are not provided
 - `nacos-cli` - Uses default `market.hiclaw.io:80` when neither `--host` nor `--port` is provided
 - `nacos-cli --host 127.0.0.1` - Uses `127.0.0.1:8848` because `--host` was provided without `--port`
 - `nacos-cli --port 8849` - Uses `127.0.0.1:8849` because only `--port` was provided

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/nacos-group/nacos-cli/internal/client"
@@ -54,12 +55,16 @@ Examples:
 		}
 
 		// Determine config loading strategy
-		// Priority: --config > env arg > default
+		// Priority: --config > profile config > env vars > default
 		var fileConfig *config.Config
 		var err error
 
 		// Check if any connection parameters are provided via command line
 		hasCommandLineConfig := host != "" || port > 0 || serverAddr != "" || username != "" || password != "" || accessKey != "" || secretKey != "" || securityToken != "" || authType == "sts-hiclaw"
+		envHost := strings.TrimSpace(os.Getenv("NACOS_HOST"))
+		envNamespace := strings.TrimSpace(os.Getenv("NACOS_NAMESPACE"))
+		envPortRaw := strings.TrimSpace(os.Getenv("NACOS_PORT"))
+		hasEnvConfig := envHost != "" || envPortRaw != "" || envNamespace != ""
 
 		if configFile != "" {
 			// Explicit config file specified
@@ -73,15 +78,28 @@ Examples:
 			if profileName != "" {
 				envName = profileName
 			}
-			// This will load, prompt for missing fields, and save
-			fileConfig, _, err = config.LoadOrCreateConfig(envName)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Error: Failed to load or create config: %v\n", err)
-				os.Exit(1)
+			if hasEnvConfig {
+				configPath, pathErr := config.GetProfileConfigPath(envName)
+				if pathErr != nil {
+					fmt.Fprintf(os.Stderr, "Warning: Failed to resolve profile config path: %v\n", pathErr)
+				} else if _, statErr := os.Stat(configPath); statErr == nil {
+					fileConfig, err = config.LoadConfig(configPath)
+					if err != nil {
+						fmt.Fprintf(os.Stderr, "Warning: Failed to load config file: %v\n", err)
+					}
+				}
+			} else {
+				// This will load, prompt for missing fields, and save
+				fileConfig, _, err = config.LoadOrCreateConfig(envName)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "Error: Failed to load or create config: %v\n", err)
+					os.Exit(1)
+				}
 			}
 		}
 
-		// Apply configuration with priority: command line > config file > default
+		// Apply configuration with priority: command line > config file > env vars > default
+		envPort := 0
 		// Server address: --server has highest priority
 		if serverAddr == "" {
 			// Try to build from --host and --port
@@ -98,18 +116,32 @@ Examples:
 			} else if port > 0 {
 				// Only port specified, use the local default host.
 				serverAddr = fmt.Sprintf("127.0.0.1:%d", port)
-			} else if fileConfig != nil {
+			} else if fileConfig != nil && fileConfig.GetServerAddr() != "" {
 				// Use from config file
 				serverAddr = fileConfig.GetServerAddr()
+			} else if envHost != "" {
+				envPort = parseNacosEnvPort(envPortRaw)
+				if envPort > 0 {
+					serverAddr = fmt.Sprintf("%s:%d", envHost, envPort)
+				} else if strings.Contains(envHost, ":") {
+					serverAddr = envHost
+				} else {
+					serverAddr = fmt.Sprintf("%s:8848", envHost)
+				}
+			} else if envPortRaw != "" {
+				serverAddr = fmt.Sprintf("127.0.0.1:%d", parseNacosEnvPort(envPortRaw))
 			}
 		}
 
-		// Namespace: command line > config file > default (empty)
+		// Namespace: command line > config file > env var > default (empty)
 		if namespace == "" && fileConfig != nil && fileConfig.Namespace != "" {
 			namespace = fileConfig.Namespace
 		}
+		if namespace == "" && envNamespace != "" {
+			namespace = envNamespace
+		}
 
-		// AuthType: command line > config file > env var > auto-detect by NewNacosClient
+		// AuthType: command line > config file > env var > client credential inference
 		if authType == "" && fileConfig != nil && fileConfig.AuthType != "" {
 			authType = fileConfig.AuthType
 		}
@@ -168,18 +200,6 @@ Examples:
 				fmt.Fprintf(os.Stderr, "Error: sts-hiclaw auth requires HICLAW_CONTROLLER_URL and HICLAW_AUTH_TOKEN_FILE environment variables\n")
 				os.Exit(1)
 			}
-		} else if authType == "" && os.Getenv("HICLAW_CONTROLLER_URL") != "" && os.Getenv("HICLAW_AUTH_TOKEN_FILE") != "" {
-			// Auto-detect sts-hiclaw auth from environment variables
-			authType = "sts-hiclaw"
-			controllerURL := os.Getenv("HICLAW_CONTROLLER_URL")
-			stsURL = strings.TrimRight(controllerURL, "/") + "/api/v1/credentials/sts"
-			tokenFile := os.Getenv("HICLAW_AUTH_TOKEN_FILE")
-			data, err := os.ReadFile(tokenFile)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Error: failed to read HICLAW_AUTH_TOKEN_FILE (%s): %v\n", tokenFile, err)
-				os.Exit(1)
-			}
-			stsAuthToken = strings.TrimSpace(string(data))
 		}
 
 		if verbose {
@@ -221,6 +241,18 @@ func SetVersionInfo(version, commit, date string) {
 // Execute runs the root command
 func Execute() error {
 	return rootCmd.Execute()
+}
+
+func parseNacosEnvPort(rawPort string) int {
+	if rawPort == "" {
+		return 0
+	}
+	envPort, err := strconv.Atoi(rawPort)
+	if err != nil || envPort <= 0 {
+		fmt.Fprintf(os.Stderr, "Error: invalid NACOS_PORT value %q\n", rawPort)
+		os.Exit(1)
+	}
+	return envPort
 }
 
 func init() {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,152 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestPersistentPreRunUsesNacosEnvConfig(t *testing.T) {
+	resetRootConfigForTest(t)
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("NACOS_HOST", "127.0.0.1")
+	t.Setenv("NACOS_PORT", "8848")
+	t.Setenv("NACOS_NAMESPACE", "env-ns")
+
+	rootCmd.PersistentPreRun(&cobra.Command{Use: "skill-list"}, nil)
+
+	if serverAddr != "127.0.0.1:8848" {
+		t.Fatalf("serverAddr = %q, want %q", serverAddr, "127.0.0.1:8848")
+	}
+	if namespace != "env-ns" {
+		t.Fatalf("namespace = %q, want %q", namespace, "env-ns")
+	}
+}
+
+func TestPersistentPreRunConfigOverridesNacosEnvConfig(t *testing.T) {
+	resetRootConfigForTest(t)
+	t.Setenv("NACOS_HOST", "127.0.0.1")
+	t.Setenv("NACOS_PORT", "8848")
+	t.Setenv("NACOS_NAMESPACE", "env-ns")
+
+	dir := t.TempDir()
+	configFile = filepath.Join(dir, "local.conf")
+	if err := os.WriteFile(configFile, []byte("host: 10.0.0.1\nport: 8849\nnamespace: file-ns\n"), 0600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	rootCmd.PersistentPreRun(&cobra.Command{Use: "skill-list"}, nil)
+
+	if serverAddr != "10.0.0.1:8849" {
+		t.Fatalf("serverAddr = %q, want %q", serverAddr, "10.0.0.1:8849")
+	}
+	if namespace != "file-ns" {
+		t.Fatalf("namespace = %q, want %q", namespace, "file-ns")
+	}
+}
+
+func TestPersistentPreRunCommandLineIgnoresInvalidEnvPort(t *testing.T) {
+	resetRootConfigForTest(t)
+	t.Setenv("NACOS_PORT", "bad-port")
+	host = "10.0.0.1"
+	port = 8849
+
+	rootCmd.PersistentPreRun(&cobra.Command{Use: "skill-list"}, nil)
+
+	if serverAddr != "10.0.0.1:8849" {
+		t.Fatalf("serverAddr = %q, want %q", serverAddr, "10.0.0.1:8849")
+	}
+}
+
+func TestPersistentPreRunConfigIgnoresInvalidEnvPort(t *testing.T) {
+	resetRootConfigForTest(t)
+	t.Setenv("NACOS_PORT", "bad-port")
+
+	dir := t.TempDir()
+	configFile = filepath.Join(dir, "local.conf")
+	if err := os.WriteFile(configFile, []byte("host: 10.0.0.1\nport: 8849\n"), 0600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	rootCmd.PersistentPreRun(&cobra.Command{Use: "skill-list"}, nil)
+
+	if serverAddr != "10.0.0.1:8849" {
+		t.Fatalf("serverAddr = %q, want %q", serverAddr, "10.0.0.1:8849")
+	}
+}
+
+func TestPersistentPreRunDoesNotAutoDetectStsHiclaw(t *testing.T) {
+	resetRootConfigForTest(t)
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("NACOS_HOST", "127.0.0.1")
+	t.Setenv("HICLAW_CONTROLLER_URL", "http://controller")
+	t.Setenv("HICLAW_AUTH_TOKEN_FILE", filepath.Join(t.TempDir(), "token"))
+
+	rootCmd.PersistentPreRun(&cobra.Command{Use: "skill-list"}, nil)
+
+	if authType != "" {
+		t.Fatalf("authType = %q, want empty", authType)
+	}
+	if stsURL != "" {
+		t.Fatalf("stsURL = %q, want empty", stsURL)
+	}
+	if stsAuthToken != "" {
+		t.Fatalf("stsAuthToken = %q, want empty", stsAuthToken)
+	}
+}
+
+func resetRootConfigForTest(t *testing.T) {
+	t.Helper()
+
+	originalServerAddr := serverAddr
+	originalHost := host
+	originalPort := port
+	originalNamespace := namespace
+	originalAuthType := authType
+	originalUsername := username
+	originalPassword := password
+	originalAccessKey := accessKey
+	originalSecretKey := secretKey
+	originalSecurityToken := securityToken
+	originalStsURL := stsURL
+	originalStsAuthToken := stsAuthToken
+	originalConfigFile := configFile
+	originalProfileName := profileName
+	originalVerbose := verbose
+
+	serverAddr = ""
+	host = ""
+	port = 0
+	namespace = ""
+	authType = ""
+	username = ""
+	password = ""
+	accessKey = ""
+	secretKey = ""
+	securityToken = ""
+	stsURL = ""
+	stsAuthToken = ""
+	configFile = ""
+	profileName = ""
+	verbose = false
+
+	t.Cleanup(func() {
+		serverAddr = originalServerAddr
+		host = originalHost
+		port = originalPort
+		namespace = originalNamespace
+		authType = originalAuthType
+		username = originalUsername
+		password = originalPassword
+		accessKey = originalAccessKey
+		secretKey = originalSecretKey
+		securityToken = originalSecurityToken
+		stsURL = originalStsURL
+		stsAuthToken = originalStsAuthToken
+		configFile = originalConfigFile
+		profileName = originalProfileName
+		verbose = originalVerbose
+	})
+}


### PR DESCRIPTION
## Summary
- support NACOS_HOST, NACOS_PORT, and NACOS_NAMESPACE as connection fallbacks
- preserve priority as command-line flags > config/profile > environment variables > defaults
- avoid auto-detecting sts-hiclaw from HICLAW_CONTROLLER_URL/HICLAW_AUTH_TOKEN_FILE unless authType is explicitly sts-hiclaw
- document the supported environment variables

## Tests
- go test ./cmd

## Notes
- GitNexus MCP tools were not available in this session. The fallback GitNexus CLI command failed with: Cannot destructure property 'package' of 'node.target' as it is null.