### PR TITLE
Makefile: self-documenting help & platform build separation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,10 @@
-.PHONY: build clean install test run-dev build-all
+# Mark targets as phony (not actual files)
+.PHONY: help \
+	build build-linux build-darwin build-windows build-all package-all \
+	clean deps test test-integration install run-dev
+
+# Set default target when running 'make' without arguments
+.DEFAULT_GOAL := build
 
 # Binary name
 BINARY_NAME=nacos-cli
@@ -22,35 +28,35 @@ GOGET=$(GOCMD) get
 GOMOD=$(GOCMD) mod
 LDFLAGS=-s -w -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)
 
-# Build the project
-build:
+help: ## Show help information
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z0-9._-]+:.*?## / {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+build: ## Build the binary
 	@echo "Building $(BINARY_NAME)..."
 	@mkdir -p $(BUILD_DIR)
 	$(GOBUILD) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME) -v
 
-# Build for all platforms
-build-all: build-linux build-darwin build-windows package-all
-
-build-linux:
+build-linux: ## Build for Linux (amd64, arm64)
 	@echo "Building for Linux..."
 	@mkdir -p $(BUILD_DIR)/$(VERSION)
 	GOOS=linux GOARCH=amd64 $(GOBUILD) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME)-$(VERSION)-linux-amd64 -v
 	GOOS=linux GOARCH=arm64 $(GOBUILD) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME)-$(VERSION)-linux-arm64 -v
 
-build-darwin:
+build-darwin: ## Build for macOS (amd64, arm64)
 	@echo "Building for macOS..."
 	@mkdir -p $(BUILD_DIR)/$(VERSION)
 	GOOS=darwin GOARCH=amd64 $(GOBUILD) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME)-$(VERSION)-darwin-amd64 -v
 	GOOS=darwin GOARCH=arm64 $(GOBUILD) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME)-$(VERSION)-darwin-arm64 -v
 
-build-windows:
+build-windows: ## Build for Windows (amd64, arm64)
 	@echo "Building for Windows..."
 	@mkdir -p $(BUILD_DIR)/$(VERSION)
 	GOOS=windows GOARCH=amd64 $(GOBUILD) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME)-$(VERSION)-windows-amd64.exe -v
 	GOOS=windows GOARCH=arm64 $(GOBUILD) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME)-$(VERSION)-windows-arm64.exe -v
 
-# Package all binaries into versioned directory as zip files
-package-all:
+build-all: build-linux build-darwin build-windows package-all ## Build for all platforms
+
+package-all: ## Package all binaries into zip files
 	@echo "Packaging binaries..."
 	@mkdir -p $(BUILD_DIR)/$(VERSION)
 	@cd $(BUILD_DIR) && for f in $(BINARY_NAME)-$(VERSION)-linux-amd64 $(BINARY_NAME)-$(VERSION)-linux-arm64 $(BINARY_NAME)-$(VERSION)-darwin-amd64 $(BINARY_NAME)-$(VERSION)-darwin-arm64; do \
@@ -60,45 +66,27 @@ package-all:
 	@cd $(BUILD_DIR) && zip "$(VERSION)/$(BINARY_NAME)-$(VERSION)-windows-arm64.zip" "$(BINARY_NAME)-$(VERSION)-windows-arm64.exe"
 	@echo "Packaged to $(BUILD_DIR)/$(VERSION)/"
 
-# Clean build artifacts
-clean:
+clean: ## Clean build artifacts
 	@echo "Cleaning..."
 	@$(GOCLEAN)
 	@rm -rf $(BUILD_DIR)
 
-# Install dependencies
-deps:
+deps: ## Download dependencies
 	@echo "Downloading dependencies..."
 	@$(GOMOD) download
 	@$(GOMOD) tidy
 
-# Run tests
-test:
+test: ## Run unit tests
 	@echo "Running tests..."
 	@$(GOTEST) -v ./...
 
-# Run integration tests
-test-integration:
+test-integration: ## Run integration tests
 	@echo "Running integration tests..."
 	@./test.sh
 
-# Install the binary
-install: build
+install: build ## Install the binary to /usr/local/bin
 	@echo "Installing $(BINARY_NAME)..."
 	@cp $(BUILD_DIR)/$(BINARY_NAME) /usr/local/bin/
 
-# Run in development mode
-run-dev:
+run-dev: ## Run in development mode
 	@$(GOCMD) run main.go
-
-# Show help
-help:
-	@echo "Nacos CLI Build Commands:"
-	@echo "  make build             - Build the binary"
-	@echo "  make build-all         - Build for all platforms"
-	@echo "  make clean             - Clean build artifacts"
-	@echo "  make deps              - Download dependencies"
-	@echo "  make test              - Run unit tests"
-	@echo "  make test-integration  - Run integration tests"
-	@echo "  make install           - Install the binary"
-	@echo "  make run-dev           - Run in development mode"

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,8 @@ GOMOD=$(GOCMD) mod
 LDFLAGS=-s -w -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)
 
 help: ## Show help information
-	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z0-9._-]+:.*?## / {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+	@echo "Nacos CLI Build Commands:"
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z0-9._-]+:.*?## / {printf "\033[36m  make %-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
 build: ## Build the binary
 	@echo "Building $(BINARY_NAME)..."


### PR DESCRIPTION
https://github.com/nacos-group/nacos-cli/issues/54

**描述 / Description**:

- help 目标改为自文档化（`##` 注释 + awk 自动解析）/ Changed help target to self-documenting (`##` comments + awk auto-parsing)
- 拆分 `build-linux`、`build-darwin`、`build-windows` 为独立目标 / Split `build-linux`, `build-darwin`, `build-windows` into standalone targets
- `install` 显式依赖 `build` / `install` explicitly depends on `build`
- 新增 `.DEFAULT_GOAL := build` / Added `.DEFAULT_GOAL := build`
- 规范化 `.PHONY` 声明 / Normalized `.PHONY` declarations