### PR TITLE
[codex] Add skill visibility and metadata tags commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,27 @@ nacos> skill-release skill-creator --version 0.0.2
 > `HTTP 400 parameter validate error` just after `skill-review`, wait and retry
 > when `skill-describe` shows the version as `reviewed`.
 
+#### Manage Skill Visibility and Tags
+
+Set skill visibility scope:
+
+```bash
+nacos-cli skill-scope skill-creator --scope PUBLIC
+nacos-cli skill-scope skill-creator --scope PRIVATE
+
+# Terminal mode
+nacos> skill-scope skill-creator --scope PUBLIC
+```
+
+Set skill metadata tags:
+
+```bash
+nacos-cli skill-tags skill-creator --tags retail,finance
+
+# Terminal mode
+nacos> skill-tags skill-creator --tags retail,finance
+```
+
 #### Publish Skill (deprecated)
 
 `skill-publish` is kept as a backward-compatible shortcut that runs
@@ -449,6 +470,8 @@ nacos-cli/
 │   ├── upload_skill.go        # skill-upload
 │   ├── review_skill.go        # skill-review
 │   ├── release_skill.go       # skill-release
+│   ├── update_skill_scope.go  # skill-scope
+│   ├── update_skill_tags.go   # skill-tags
 │   ├── publish_skill.go       # skill-publish (deprecated wrapper)
 │   ├── sync_skill.go          # skill-sync
 │   ├── list_agentspec.go      # agentspec-list

--- a/cmd/describe_skill.go
+++ b/cmd/describe_skill.go
@@ -88,6 +88,9 @@ func renderSkillDetailPretty(d *skill.SkillDetail) {
 	if d.Scope != "" {
 		meta = append(meta, "scope="+d.Scope)
 	}
+	if d.BizTags != "" {
+		meta = append(meta, "bizTags="+d.BizTags)
+	}
 	if d.Owner != "" {
 		meta = append(meta, "owner="+d.Owner)
 	}

--- a/cmd/list_skill.go
+++ b/cmd/list_skill.go
@@ -138,6 +138,9 @@ func printSkillListItem(idx int, s skill.SkillListItem) {
 	if s.Scope != "" {
 		meta = append(meta, "scope="+s.Scope)
 	}
+	if s.BizTags != "" {
+		meta = append(meta, "bizTags="+s.BizTags)
+	}
 	if s.Owner != "" {
 		meta = append(meta, "owner="+s.Owner)
 	}

--- a/cmd/update_skill_scope.go
+++ b/cmd/update_skill_scope.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/nacos-group/nacos-cli/internal/help"
+	"github.com/nacos-group/nacos-cli/internal/skill"
+	"github.com/spf13/cobra"
+)
+
+var skillScopeValue string
+
+var updateSkillScopeCmd = &cobra.Command{
+	Use:     "skill-scope [skillName]",
+	Aliases: []string{"skill-visibility"},
+	Short:   "Set skill visibility scope",
+	Long:    help.SkillScope.FormatForCLI("nacos-cli"),
+	Args:    cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		if skillScopeValue == "" {
+			fmt.Fprintln(os.Stderr, "Error: --scope is required for skill-scope")
+			os.Exit(1)
+		}
+
+		nacosClient := mustNewNacosClient()
+		skillService := skill.NewSkillService(nacosClient)
+
+		if err := skillService.UpdateSkillScope(args[0], skillScopeValue); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: failed to update skill scope for '%s': %v\n", args[0], err)
+			os.Exit(1)
+		}
+		fmt.Printf("Skill scope updated successfully: %s -> %s\n", args[0], skillScopeValue)
+	},
+}
+
+func init() {
+	updateSkillScopeCmd.Flags().StringVar(&skillScopeValue, "scope", "", "Required. Visibility scope: PUBLIC or PRIVATE")
+	rootCmd.AddCommand(updateSkillScopeCmd)
+}

--- a/cmd/update_skill_tags.go
+++ b/cmd/update_skill_tags.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/nacos-group/nacos-cli/internal/help"
+	"github.com/nacos-group/nacos-cli/internal/skill"
+	"github.com/spf13/cobra"
+)
+
+var skillTagsValue string
+
+var updateSkillTagsCmd = &cobra.Command{
+	Use:     "skill-tags [skillName]",
+	Aliases: []string{"skill-biz-tags"},
+	Short:   "Set skill metadata tags",
+	Long:    help.SkillTags.FormatForCLI("nacos-cli"),
+	Args:    cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		if skillTagsValue == "" {
+			fmt.Fprintln(os.Stderr, "Error: --tags is required for skill-tags")
+			os.Exit(1)
+		}
+
+		nacosClient := mustNewNacosClient()
+		skillService := skill.NewSkillService(nacosClient)
+
+		if err := skillService.UpdateSkillBizTags(args[0], skillTagsValue); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: failed to update skill tags for '%s': %v\n", args[0], err)
+			os.Exit(1)
+		}
+		fmt.Printf("Skill tags updated successfully: %s -> %s\n", args[0], skillTagsValue)
+	},
+}
+
+func init() {
+	updateSkillTagsCmd.Flags().StringVar(&skillTagsValue, "tags", "", "Required. Skill metadata tags, for example retail,finance")
+	rootCmd.AddCommand(updateSkillTagsCmd)
+}

--- a/internal/help/help.go
+++ b/internal/help/help.go
@@ -132,6 +132,35 @@ var (
 		},
 	}
 
+	SkillScope = CommandHelp{
+		Command:     "skill-scope",
+		Description: "Set the visibility scope of a skill.",
+		Parameters: []string{
+			"skillName       Required. Skill name",
+			"--scope         Required. Visibility scope: PUBLIC or PRIVATE",
+		},
+		Examples: []string{
+			"# Make a skill public",
+			"skill-scope my-skill --scope PUBLIC",
+			"",
+			"# Make a skill private",
+			"skill-scope my-skill --scope PRIVATE",
+		},
+	}
+
+	SkillTags = CommandHelp{
+		Command:     "skill-tags",
+		Description: "Set metadata tags for a skill.",
+		Parameters: []string{
+			"skillName       Required. Skill name",
+			"--tags          Required. Skill metadata tags, for example retail,finance",
+		},
+		Examples: []string{
+			"# Set metadata tags",
+			"skill-tags my-skill --tags retail,finance",
+		},
+	}
+
 	SkillDescribe = CommandHelp{
 		Command:     "skill-describe",
 		Description: "Show detailed info of a single skill, including governance metadata and the full version list with per-version status (editing/reviewing/online/offline).",

--- a/internal/skill/skill_service.go
+++ b/internal/skill/skill_service.go
@@ -195,6 +195,105 @@ func (s *SkillService) DescribeSkill(skillName string) (*SkillDetail, error) {
 	return &detail, nil
 }
 
+// UpdateSkillScope sets the skill visibility scope (PUBLIC or PRIVATE).
+func (s *SkillService) UpdateSkillScope(skillName, scope string) error {
+	if err := s.client.EnsureTokenValid(); err != nil {
+		return err
+	}
+	if strings.TrimSpace(skillName) == "" {
+		return fmt.Errorf("skillName is required")
+	}
+	normalizedScope, err := normalizeSkillScope(scope)
+	if err != nil {
+		return err
+	}
+
+	params := url.Values{}
+	params.Set("namespaceId", s.client.Namespace)
+	params.Set("skillName", skillName)
+	params.Set("scope", normalizedScope)
+
+	scopeURL := fmt.Sprintf("http://%s/nacos/v3/admin/ai/skills/scope?%s",
+		s.client.ServerAddr, params.Encode())
+	req, err := s.client.NewAuthedRequest("PUT", scopeURL, nil)
+	if err != nil {
+		return err
+	}
+
+	httpClient := &http.Client{}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("update skill scope failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	return checkV3Response(resp, "update skill scope")
+}
+
+// UpdateSkillBizTags sets skill metadata tags.
+func (s *SkillService) UpdateSkillBizTags(skillName, bizTags string) error {
+	if err := s.client.EnsureTokenValid(); err != nil {
+		return err
+	}
+	if strings.TrimSpace(skillName) == "" {
+		return fmt.Errorf("skillName is required")
+	}
+	bizTags = strings.TrimSpace(bizTags)
+	if bizTags == "" {
+		return fmt.Errorf("bizTags are required")
+	}
+
+	params := url.Values{}
+	params.Set("namespaceId", s.client.Namespace)
+	params.Set("skillName", skillName)
+	params.Set("bizTags", bizTags)
+
+	bizTagsURL := fmt.Sprintf("http://%s/nacos/v3/admin/ai/skills/biz-tags?%s",
+		s.client.ServerAddr, params.Encode())
+	req, err := s.client.NewAuthedRequest("PUT", bizTagsURL, nil)
+	if err != nil {
+		return err
+	}
+
+	httpClient := &http.Client{}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("update skill bizTags failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	return checkV3Response(resp, "update skill bizTags")
+}
+
+func normalizeSkillScope(scope string) (string, error) {
+	normalized := strings.ToUpper(strings.TrimSpace(scope))
+	switch normalized {
+	case "PUBLIC", "PRIVATE":
+		return normalized, nil
+	default:
+		return "", fmt.Errorf("scope must be PUBLIC or PRIVATE")
+	}
+}
+
+func checkV3Response(resp *http.Response, operation string) error {
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read %s response failed: %w", operation, err)
+	}
+	if resp.StatusCode != 200 {
+		return client.ParseHTTPError(resp.StatusCode, respBody, operation)
+	}
+
+	var v3Resp V3Response
+	if err := json.Unmarshal(respBody, &v3Resp); err != nil {
+		return fmt.Errorf("parse %s response failed: %w", operation, err)
+	}
+	if v3Resp.Code != 0 {
+		return fmt.Errorf("%s failed: code=%d, message=%s", operation, v3Resp.Code, v3Resp.Message)
+	}
+	return nil
+}
+
 // GetSkill downloads a skill as ZIP via the Client Skill API and extracts it to local directory.
 // The server returns a ZIP binary stream containing skillName/SKILL.md and resource files.
 // Priority for version resolution: label > version > latest.

--- a/internal/skill/skill_service_test.go
+++ b/internal/skill/skill_service_test.go
@@ -60,7 +60,7 @@ func TestUploadSkillOnlyUploadsDraft(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	nacosClient, err := client.NewNacosClient(strings.TrimPrefix(server.URL, "http://"), "test-ns", client.AuthTypeToken, "", "", "", "", "token")
+	nacosClient, err := newTestNacosClient(server.URL)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -97,7 +97,7 @@ func TestSubmitSkillSendsFormParams(t *testing.T) {
 	}))
 	defer server.Close()
 
-	nacosClient, err := client.NewNacosClient(strings.TrimPrefix(server.URL, "http://"), "test-ns", client.AuthTypeToken, "", "", "", "", "token")
+	nacosClient, err := newTestNacosClient(server.URL)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -108,4 +108,93 @@ func TestSubmitSkillSendsFormParams(t *testing.T) {
 	if !submitCalled {
 		t.Fatal("submit was not called")
 	}
+}
+
+func TestUpdateSkillScopeSendsParams(t *testing.T) {
+	var scopeCalled bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/nacos/v3/admin/ai/skills/scope" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		scopeCalled = true
+		if r.Method != http.MethodPut {
+			t.Fatalf("scope method = %s, want PUT", r.Method)
+		}
+		if got := r.URL.Query().Get("namespaceId"); got != "test-ns" {
+			t.Fatalf("scope namespaceId = %s, want test-ns", got)
+		}
+		if got := r.URL.Query().Get("skillName"); got != "demo-skill" {
+			t.Fatalf("scope skillName = %s, want demo-skill", got)
+		}
+		if got := r.URL.Query().Get("scope"); got != "PUBLIC" {
+			t.Fatalf("scope = %s, want PUBLIC", got)
+		}
+		_ = json.NewEncoder(w).Encode(V3Response{Code: 0, Message: "success"})
+	}))
+	defer server.Close()
+
+	nacosClient, err := newTestNacosClient(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := NewSkillService(nacosClient).UpdateSkillScope("demo-skill", "public"); err != nil {
+		t.Fatal(err)
+	}
+	if !scopeCalled {
+		t.Fatal("scope was not called")
+	}
+}
+
+func TestUpdateSkillBizTagsSendsParams(t *testing.T) {
+	var bizTagsCalled bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/nacos/v3/admin/ai/skills/biz-tags" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		bizTagsCalled = true
+		if r.Method != http.MethodPut {
+			t.Fatalf("bizTags method = %s, want PUT", r.Method)
+		}
+		if got := r.URL.Query().Get("namespaceId"); got != "test-ns" {
+			t.Fatalf("bizTags namespaceId = %s, want test-ns", got)
+		}
+		if got := r.URL.Query().Get("skillName"); got != "demo-skill" {
+			t.Fatalf("bizTags skillName = %s, want demo-skill", got)
+		}
+		if got := r.URL.Query().Get("bizTags"); got != "retail,finance" {
+			t.Fatalf("bizTags = %s, want retail,finance", got)
+		}
+		_ = json.NewEncoder(w).Encode(V3Response{Code: 0, Message: "success"})
+	}))
+	defer server.Close()
+
+	nacosClient, err := newTestNacosClient(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := NewSkillService(nacosClient).UpdateSkillBizTags("demo-skill", "retail,finance"); err != nil {
+		t.Fatal(err)
+	}
+	if !bizTagsCalled {
+		t.Fatal("bizTags was not called")
+	}
+}
+
+func newTestNacosClient(serverURL string) (*client.NacosClient, error) {
+	return client.NewNacosClient(
+		strings.TrimPrefix(serverURL, "http://"),
+		"test-ns",
+		client.AuthTypeNone,
+		"",
+		"",
+		"",
+		"",
+		"",
+		"",
+		"",
+	)
 }

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -101,6 +101,16 @@ func completer() *readline.PrefixCompleter {
 			readline.PcItem("--version"),
 			readline.PcItem("--update-latest"),
 		),
+		readline.PcItem("skill-scope",
+			readline.PcItem("--help"),
+			readline.PcItem("-h"),
+			readline.PcItem("--scope"),
+		),
+		readline.PcItem("skill-tags",
+			readline.PcItem("--help"),
+			readline.PcItem("-h"),
+			readline.PcItem("--tags"),
+		),
 		readline.PcItem("agentspec-list",
 			readline.PcItem("--help"),
 			readline.PcItem("-h"),
@@ -340,6 +350,18 @@ func (t *Terminal) handleCommand(input string) {
 		} else {
 			t.releaseSkill(args)
 		}
+	case "skill-scope", "skill-visibility":
+		if len(args) > 0 && (args[0] == "--help" || args[0] == "-h") {
+			t.showSkillScopeHelp()
+		} else {
+			t.updateSkillScope(args)
+		}
+	case "skill-tags", "skill-biz-tags":
+		if len(args) > 0 && (args[0] == "--help" || args[0] == "-h") {
+			t.showSkillTagsHelp()
+		} else {
+			t.updateSkillTags(args)
+		}
 	case "skill-sync":
 		fmt.Println("\033[33mskill-sync has been removed.\033[0m")
 		fmt.Println("\033[90mUse 'skill-get' to download skills.\033[0m")
@@ -433,6 +455,8 @@ func (t *Terminal) showHelp() {
 	fmt.Printf("\033[32m%-20s\033[0m %-40s %-30s\n", "", "Upload all skills in directory", "skill-upload --all <folder>")
 	fmt.Printf("\033[32m%-20s\033[0m %-40s %-30s\n", "skill-review", "Submit a draft for review", "skill-review <name> [--version v1]")
 	fmt.Printf("\033[32m%-20s\033[0m %-40s %-30s\n", "skill-release", "Release an approved version", "skill-release <name> --version v1")
+	fmt.Printf("\033[32m%-20s\033[0m %-40s %-30s\n", "skill-scope", "Set skill visibility", "skill-scope <name> --scope PUBLIC")
+	fmt.Printf("\033[32m%-20s\033[0m %-40s %-30s\n", "skill-tags", "Set metadata tags", "skill-tags <name> --tags a,b")
 	fmt.Printf("\033[32m%-20s\033[0m %-40s %-30s\n", "skill-publish", "[DEPRECATED] upload + review", "skill-publish <path> (use skill-upload/review)")
 	fmt.Println()
 
@@ -635,6 +659,9 @@ func (t *Terminal) printSkillSummaryLine(idx int, s skill.SkillListItem) {
 	if s.Scope != "" {
 		meta = append(meta, "scope="+s.Scope)
 	}
+	if s.BizTags != "" {
+		meta = append(meta, "bizTags="+s.BizTags)
+	}
 	if s.Owner != "" {
 		meta = append(meta, "owner="+s.Owner)
 	}
@@ -697,6 +724,9 @@ func (t *Terminal) describeSkill(args []string) {
 	var meta []string
 	if detail.Scope != "" {
 		meta = append(meta, "scope="+detail.Scope)
+	}
+	if detail.BizTags != "" {
+		meta = append(meta, "bizTags="+detail.BizTags)
 	}
 	if detail.Owner != "" {
 		meta = append(meta, "owner="+detail.Owner)
@@ -1086,6 +1116,66 @@ func (t *Terminal) releaseSkill(args []string) {
 	fmt.Printf("Skill released successfully! %s@%s is now online.\n", skillName, version)
 }
 
+// updateSkillScope sets skill visibility scope.
+func (t *Terminal) updateSkillScope(args []string) {
+	if len(args) == 0 {
+		fmt.Println("Usage: skill-scope <skillName> --scope <PUBLIC|PRIVATE>")
+		return
+	}
+
+	skillName := args[0]
+	scope := ""
+	for i := 1; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--scope" && i+1 < len(args) {
+			i++
+			scope = args[i]
+		} else if strings.HasPrefix(arg, "--scope=") {
+			scope = strings.TrimPrefix(arg, "--scope=")
+		}
+	}
+	if scope == "" {
+		fmt.Println("Error: --scope is required for skill-scope")
+		return
+	}
+
+	if err := t.skillService.UpdateSkillScope(skillName, scope); err != nil {
+		fmt.Printf("Error: %v\n", err)
+		return
+	}
+	fmt.Printf("Skill scope updated successfully: %s -> %s\n", skillName, scope)
+}
+
+// updateSkillTags sets skill metadata tags.
+func (t *Terminal) updateSkillTags(args []string) {
+	if len(args) == 0 {
+		fmt.Println("Usage: skill-tags <skillName> --tags <tags>")
+		return
+	}
+
+	skillName := args[0]
+	tags := ""
+	for i := 1; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--tags" && i+1 < len(args) {
+			i++
+			tags = args[i]
+		} else if strings.HasPrefix(arg, "--tags=") {
+			tags = strings.TrimPrefix(arg, "--tags=")
+		}
+	}
+	if tags == "" {
+		fmt.Println("Error: --tags is required for skill-tags")
+		return
+	}
+
+	if err := t.skillService.UpdateSkillBizTags(skillName, tags); err != nil {
+		fmt.Printf("Error: %v\n", err)
+		return
+	}
+	fmt.Printf("Skill tags updated successfully: %s -> %s\n", skillName, tags)
+}
+
 // publishLegacy runs upload + review as a backward-compatible shortcut for the
 // deprecated skill-publish command.
 func (t *Terminal) publishLegacy(args []string) {
@@ -1414,6 +1504,14 @@ func (t *Terminal) showSkillReviewHelp() {
 
 func (t *Terminal) showSkillReleaseHelp() {
 	help.SkillRelease.FormatForTerminal()
+}
+
+func (t *Terminal) showSkillScopeHelp() {
+	help.SkillScope.FormatForTerminal()
+}
+
+func (t *Terminal) showSkillTagsHelp() {
+	help.SkillTags.FormatForTerminal()
 }
 
 func (t *Terminal) showConfigListHelp() {


### PR DESCRIPTION
## Summary

- add `skill-scope` to update skill visibility (`PUBLIC` / `PRIVATE`)
- add `skill-tags` to update normal skill metadata tags (`bizTags`)
- show skill metadata tags in `skill-list` / `skill-describe`
- document the new commands and wire them into terminal mode

This intentionally does not add version route label or gray-release label management. There is no `skill-labels` command and no `/skills/labels` call.

## Validation

- `go test ./...`
- `go run . skill-scope --help`
- `go run . skill-tags --help`
- checked that `skill-labels`, `UpdateSkillLabels`, and `/skills/labels` are absent from the staged diff

## Notes

GitNexus detect could not run in this environment because `npx gitnexus@latest` failed to resolve the configured npm registry.
