### PR TITLE
fix: remove extra directory prefix in ZIP and use forward slashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,6 +542,15 @@ MIT License
 
 ## Changelog
 
+### Next Release
+
+- Fixed `skill-upload` and `agentspec-upload` creating ZIP archives with an
+  extra directory prefix, causing server-side extraction failures
+  ([#46](https://github.com/nacos-group/nacos-cli/issues/46))
+- Fixed ZIP archive paths using OS-native backslashes on Windows, violating
+  the ZIP specification's forward-slash requirement
+  ([#26](https://github.com/nacos-group/nacos-cli/issues/26))
+
 ### v1.0.4 (2026-05-08)
 
 - Aligned `agentspec-*` commands with `skill-*` around the full server lifecycle

--- a/internal/agentspec/agentspec_service.go
+++ b/internal/agentspec/agentspec_service.go
@@ -320,7 +320,10 @@ func (s *AgentSpecService) UploadAgentSpec(agentSpecPath string) error {
 			if err != nil {
 				return err
 			}
-			zipPath := filepath.Join(specName, relPath)
+			// Use forward slashes for ZIP paths (required by ZIP spec) and
+			// do NOT prefix with specName — server expects files at the root
+			// of the archive (e.g. AGENTSPEC.md, not specName/AGENTSPEC.md).
+			zipPath := filepath.ToSlash(relPath)
 			writer, err := zipWriter.Create(zipPath)
 			if err != nil {
 				return err

--- a/internal/agentspec/agentspec_service_test.go
+++ b/internal/agentspec/agentspec_service_test.go
@@ -1,8 +1,18 @@
 package agentspec
 
 import (
+	"archive/zip"
+	"bytes"
 	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/nacos-group/nacos-cli/internal/client"
 )
 
 func TestBuildResourceRelativePath(t *testing.T) {
@@ -110,5 +120,93 @@ func TestAgentSpecResource_Metadata(t *testing.T) {
 
 	if size, ok := res.Metadata["size"]; !ok || size != "1024" {
 		t.Errorf("Expected size '1024', got %v", size)
+	}
+}
+
+// TestUploadAgentSpecZipPaths verifies that:
+// 1. ZIP entries have NO extra specName/ prefix (#46)
+// 2. ZIP entries use forward slashes even on Windows (#26)
+func TestUploadAgentSpecZipPaths(t *testing.T) {
+	var zipData []byte
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/nacos/v3/admin/ai/agentspecs/upload" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if err := r.ParseMultipartForm(1 << 20); err != nil {
+			t.Fatalf("parse multipart: %v", err)
+		}
+		file, _, err := r.FormFile("file")
+		if err != nil {
+			t.Fatalf("read uploaded file: %v", err)
+		}
+		defer file.Close()
+		zipData, err = io.ReadAll(file)
+		if err != nil {
+			t.Fatalf("read upload body: %v", err)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	// Create an agentspec directory with nested subdirectory
+	specDir := filepath.Join(t.TempDir(), "my-agent")
+	subDir := filepath.Join(specDir, "resources", "config")
+	if err := os.MkdirAll(subDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(specDir, "AGENTSPEC.md"), []byte("# My Agent\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(subDir, "app.yaml"), []byte("key: value\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	nacosClient, err := client.NewNacosClient(
+		strings.TrimPrefix(server.URL, "http://"),
+		"test-ns",
+		client.AuthTypeNone,
+		"", "", "", "", "", "", "",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	svc := NewAgentSpecService(nacosClient)
+	if err := svc.UploadAgentSpec(specDir); err != nil {
+		t.Fatal(err)
+	}
+
+	// Parse the ZIP and verify paths
+	reader, err := zip.NewReader(bytes.NewReader(zipData), int64(len(zipData)))
+	if err != nil {
+		t.Fatalf("open zip: %v", err)
+	}
+
+	expectedPaths := map[string]bool{
+		"AGENTSPEC.md":           false,
+		"resources/config/app.yaml": false,
+	}
+
+	for _, f := range reader.File {
+		// Verify no backslashes (Windows path separator)
+		if strings.Contains(f.Name, "\\") {
+			t.Errorf("ZIP entry contains backslash: %q", f.Name)
+		}
+		// Verify no specName prefix
+		if strings.HasPrefix(f.Name, "my-agent/") {
+			t.Errorf("ZIP entry has unexpected specName prefix: %q", f.Name)
+		}
+		if _, ok := expectedPaths[f.Name]; ok {
+			expectedPaths[f.Name] = true
+		} else {
+			t.Errorf("unexpected ZIP entry: %q", f.Name)
+		}
+	}
+
+	for path, found := range expectedPaths {
+		if !found {
+			t.Errorf("expected ZIP entry not found: %q", path)
+		}
 	}
 }

--- a/internal/skill/skill_service.go
+++ b/internal/skill/skill_service.go
@@ -423,7 +423,10 @@ func (s *SkillService) UploadSkill(skillPath string) error {
 			if err != nil {
 				return err
 			}
-			zipPath := filepath.Join(skillName, relPath)
+			// Use forward slashes for ZIP paths (required by ZIP spec) and
+			// do NOT prefix with skillName — server expects files at the root
+			// of the archive (e.g. SKILL.md, not skillName/SKILL.md).
+			zipPath := filepath.ToSlash(relPath)
 			writer, err := zipWriter.Create(zipPath)
 			if err != nil {
 				return err

--- a/internal/skill/skill_service_test.go
+++ b/internal/skill/skill_service_test.go
@@ -1,11 +1,14 @@
 package skill
 
 import (
+	"archive/zip"
+	"bytes"
 	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -197,4 +200,86 @@ func newTestNacosClient(serverURL string) (*client.NacosClient, error) {
 		"",
 		"",
 	)
+}
+
+// TestUploadSkillZipPaths verifies that:
+// 1. ZIP entries have NO extra skillName/ prefix (#46)
+// 2. ZIP entries use forward slashes even on Windows (#26)
+func TestUploadSkillZipPaths(t *testing.T) {
+	var zipData []byte
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/nacos/v3/admin/ai/skills/upload" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if err := r.ParseMultipartForm(1 << 20); err != nil {
+			t.Fatalf("parse multipart: %v", err)
+		}
+		file, _, err := r.FormFile("file")
+		if err != nil {
+			t.Fatalf("read uploaded file: %v", err)
+		}
+		defer file.Close()
+		zipData, err = io.ReadAll(file)
+		if err != nil {
+			t.Fatalf("read upload body: %v", err)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	// Create a skill directory with nested subdirectory
+	skillDir := filepath.Join(t.TempDir(), "my-skill")
+	subDir := filepath.Join(skillDir, "prompts", "templates")
+	if err := os.MkdirAll(subDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("# My Skill\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(subDir, "default.txt"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	nacosClient, err := newTestNacosClient(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := NewSkillService(nacosClient).UploadSkill(skillDir); err != nil {
+		t.Fatal(err)
+	}
+
+	// Parse the ZIP and verify paths
+	reader, err := zip.NewReader(bytes.NewReader(zipData), int64(len(zipData)))
+	if err != nil {
+		t.Fatalf("open zip: %v", err)
+	}
+
+	expectedPaths := map[string]bool{
+		"SKILL.md":                     false,
+		"prompts/templates/default.txt": false,
+	}
+
+	for _, f := range reader.File {
+		// Verify no backslashes (Windows path separator)
+		if strings.Contains(f.Name, "\\") {
+			t.Errorf("ZIP entry contains backslash: %q", f.Name)
+		}
+		// Verify no skillName prefix
+		if strings.HasPrefix(f.Name, "my-skill/") {
+			t.Errorf("ZIP entry has unexpected skillName prefix: %q", f.Name)
+		}
+		if _, ok := expectedPaths[f.Name]; ok {
+			expectedPaths[f.Name] = true
+		} else {
+			t.Errorf("unexpected ZIP entry: %q", f.Name)
+		}
+	}
+
+	for path, found := range expectedPaths {
+		if !found {
+			t.Errorf("expected ZIP entry not found: %q", path)
+		}
+	}
 }


### PR DESCRIPTION
## Summary

- Remove the extra `skillName/` (or `specName/`) directory prefix when creating ZIP archives during upload, so the server can correctly extract files at the root level
- Normalize ZIP entry paths to use forward slashes via `filepath.ToSlash()`, fixing broken archives on Windows

## Problem

**#46 — ZIP multi-level directory**: `skill-upload` creates ZIP entries like `my-skill/SKILL.md` instead of `SKILL.md`. The server expects files at the archive root, causing extraction failures.

**#26 — Windows path separators**: On Windows, `filepath.Rel()` + `filepath.Join()` produce backslash paths (e.g. `prompts\templates\default.txt`), but the ZIP specification (APPNOTE 4.4.17) requires forward slashes.

## Changes

| File | Description |
|------|-------------|
| `internal/skill/skill_service.go` | Remove `filepath.Join(skillName, relPath)` → use `filepath.ToSlash(relPath)` |
| `internal/agentspec/agentspec_service.go` | Same fix for agentspec upload |
| `internal/skill/skill_service_test.go` | Add `TestUploadSkillZipPaths` — verifies no prefix and no backslashes |
| `internal/agentspec/agentspec_service_test.go` | Add `TestUploadAgentSpecZipPaths` — same verification |
| `README.md` | Add changelog entries for both fixes |

## Backward Compatibility

This is a bug fix — the previous behavior was incorrect and caused server-side failures. Users who worked around the issue (e.g. pre-packaging ZIP files manually) will not be affected.

## Test Plan

- [x] `go build ./...` passes
- [x] `go test ./...` — all packages PASS
- [x] `TestUploadSkillZipPaths`: verifies ZIP contains `SKILL.md` and `prompts/templates/default.txt` (no `my-skill/` prefix, no backslashes)
- [x] `TestUploadAgentSpecZipPaths`: verifies ZIP contains `AGENTSPEC.md` and `resources/config/app.yaml` (no `my-agent/` prefix, no backslashes)

Closes #46
Closes #26