### PR TITLE
feat: add GitHub Actions CI/CD workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Build
+        run: go build ./...
+
+      - name: Test
+        run: go test ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          TAG="${GITHUB_REF#refs/tags/v}"
+          echo "version=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Update version in package files
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          # Update package.json
+          sed -i "s/\"version\": \".*\"/\"version\": \"$VERSION\"/" package.json
+          # Update bin/cli.js
+          sed -i "s/const VERSION = '.*'/const VERSION = '$VERSION'/" bin/cli.js
+
+      - name: Build all platforms
+        run: make build-all VERSION=${{ steps.version.outputs.version }}
+
+      - name: Publish to npm
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            build/${{ steps.version.outputs.version }}/*.zip

--- a/README.md
+++ b/README.md
@@ -536,11 +536,33 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 4. Push to the branch (`git push origin feature/amazing-feature`)
 5. Open a Pull Request
 
+All pull requests are automatically tested via GitHub Actions (build + unit tests).
+
+## Release
+
+Releases are automated via GitHub Actions. To publish a new version:
+
+1. Update version numbers in `Makefile`, `package.json`, and `bin/cli.js`
+2. Commit and push to `main`
+3. Create and push a tag: `git tag v1.0.5 && git push origin v1.0.5`
+4. GitHub Actions will automatically:
+   - Cross-compile binaries for all platforms (linux/darwin/windows × amd64/arm64)
+   - Publish the npm package to `@nacos-group/cli`
+   - Create a GitHub Release with downloadable ZIP archives
+
+**Required secret**: `NPM_TOKEN` — an npm access token with publish permission for `@nacos-group/cli`, configured in the repository's Settings → Secrets → Actions.
+
 ## License
 
 MIT License
 
 ## Changelog
+
+### Next Release
+
+- Added GitHub Actions CI/CD: automatic testing on PRs and tag-triggered npm
+  publishing with cross-platform binary builds
+  ([#22](https://github.com/nacos-group/nacos-cli/issues/22))
 
 ### v1.0.4 (2026-05-08)
 


### PR DESCRIPTION
## Summary

- Add CI workflow: automatic build + test on every PR and push to main
- Add Release workflow: tag-triggered cross-platform build + npm publish + GitHub Release creation

## Workflows

### CI (`ci.yml`)
Triggered on: push to `main`, pull requests to `main`

- Sets up Go (version from `go.mod`)
- Runs `go build ./...`
- Runs `go test ./...`

### Release (`release.yml`)
Triggered on: push of tags matching `v*` (e.g. `v1.0.5`)

Steps:
1. Extract version from tag (strip `v` prefix)
2. Update `package.json` and `bin/cli.js` version numbers
3. Cross-compile binaries for 6 platforms via `make build-all`
4. `npm publish` the package as `@nacos-group/cli`
5. Create GitHub Release with platform-specific ZIP archives

## Usage

To release a new version:
```bash
git tag v1.0.5
git push origin v1.0.5
```

The workflow handles everything else automatically.

## Required Setup

Add `NPM_TOKEN` as a repository secret (Settings → Secrets → Actions) with an npm access token that has publish permission for `@nacos-group/cli`.

## Test Plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] CI workflow runs on this PR (will validate once merged)
- [ ] Release workflow validated on first tag push after merge

Closes #22