### PR TITLE
ci: add GitHub Actions for lint, test, build and release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,92 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run go vet
+        run: go vet ./...
+
+      - name: Run tests
+        run: go test -v -race -coverprofile=coverage.out ./...
+
+      - name: Upload coverage
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage.out
+
+  build:
+    name: Build (${{ matrix.goos }}/${{ matrix.goarch }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
+          - goos: darwin
+            goarch: amd64
+          - goos: darwin
+            goarch: arm64
+          - goos: windows
+            goarch: amd64
+          - goos: windows
+            goarch: arm64
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          ext=""
+          if [ "$GOOS" = "windows" ]; then ext=".exe"; fi
+          go build -o nacos-cli-${GOOS}-${GOARCH}${ext} -v .
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: nacos-cli-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: nacos-cli-*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.64.8
+          version: v1.64
 
   test:
     name: Test
@@ -52,6 +52,7 @@ jobs:
 
   build:
     name: Build (${{ matrix.goos }}/${{ matrix.goarch }})
+    needs: [lint, test]
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: latest
+          version: v1.64.8
 
   test:
     name: Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,10 @@ jobs:
         run: |
           npm version "${{ steps.version.outputs.version }}" --no-git-tag-version
 
+      - name: Update cli.js version
+        run: |
+          sed -i "s/const VERSION = '[^']*'/const VERSION = '${{ steps.version.outputs.version }}'/" bin/cli.js
+
       - name: Build all platform binaries
         run: make build-all VERSION=${{ steps.version.outputs.version }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,67 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    name: GoReleaser
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  npm-publish:
+    name: Publish npm package
+    needs: goreleaser
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+
+      - name: Update package.json version
+        run: |
+          npm version "${{ steps.version.outputs.version }}" --no-git-tag-version
+
+      - name: Build all platform binaries
+        run: make build-all VERSION=${{ steps.version.outputs.version }}
+
+      - name: Publish to npm
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,11 +45,6 @@ jobs:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
 
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-          cache: true
-
       - name: Extract version from tag
         id: version
         run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
@@ -62,10 +57,26 @@ jobs:
         run: |
           sed -i "s/const VERSION = '[^']*'/const VERSION = '${{ steps.version.outputs.version }}'/" bin/cli.js
 
-      - name: Build all platform binaries
-        run: make build-all VERSION=${{ steps.version.outputs.version }}
+      - name: Download release binaries
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          mkdir -p build
+          for PLATFORM in linux-amd64 linux-arm64 darwin-amd64 darwin-arm64; do
+            TMPDIR=$(mktemp -d)
+            gh release download "v${VERSION}" --pattern "nacos-cli-${VERSION}-${PLATFORM}.tar.gz" --dir "${TMPDIR}"
+            tar -xzf "${TMPDIR}/nacos-cli-${VERSION}-${PLATFORM}.tar.gz" -C "${TMPDIR}"
+            mv "${TMPDIR}/nacos-cli" "build/nacos-cli-${VERSION}-${PLATFORM}"
+            rm -rf "${TMPDIR}"
+          done
+          for PLATFORM in windows-amd64 windows-arm64; do
+            TMPDIR=$(mktemp -d)
+            gh release download "v${VERSION}" --pattern "nacos-cli-${VERSION}-${PLATFORM}.zip" --dir "${TMPDIR}"
+            unzip -o "${TMPDIR}/nacos-cli-${VERSION}-${PLATFORM}.zip" -d "${TMPDIR}"
+            mv "${TMPDIR}/nacos-cli.exe" "build/nacos-cli-${VERSION}-${PLATFORM}.exe"
+            rm -rf "${TMPDIR}"
+          done
 
       - name: Publish to npm
         run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build/
 
 # Binary executable
 nacos-cli
+nacos-cli-*
 bin/nacos-cli
 
 # IDE
@@ -18,6 +19,7 @@ Thumbs.db
 
 # Go
 vendor/
+coverage.out
 
 # Node
 node_modules/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,20 @@
+run:
+  timeout: 5m
+
+linters:
+  enable:
+    - errcheck
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+    - gofmt
+    - goimports
+    - misspell
+    - unconvert
+
+issues:
+  exclude-use-default: true
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,12 +25,12 @@ builds:
       - -X main.date={{.Date}}
 
 archives:
-  - format: tar.gz
+  - formats: [tar.gz]
     name_template: >-
       {{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
 
 checksum:
   name_template: "checksums.txt"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,65 @@
+version: 2
+
+project_name: nacos-cli
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - main: .
+    binary: nacos-cli
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.Commit}}
+      - -X main.date={{.Date}}
+
+archives:
+  - format: tar.gz
+    name_template: >-
+      {{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}
+    format_overrides:
+      - goos: windows
+        format: zip
+
+checksum:
+  name_template: "checksums.txt"
+
+snapshot:
+  version_template: "{{ incpatch .Version }}-next"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"
+      - "^ci:"
+  groups:
+    - title: Features
+      regexp: '^feat'
+      order: 0
+    - title: Bug Fixes
+      regexp: '^fix'
+      order: 1
+    - title: Others
+      order: 999
+
+release:
+  github:
+    owner: nacos-group
+    name: nacos-cli
+  draft: false
+  prerelease: auto
+  name_template: "v{{.Version}}"


### PR DESCRIPTION
## Summary

Add CI/CD pipeline to automate code quality checks and release process.

- **CI workflow** (`ci.yml`): golangci-lint, `go test -race` with coverage, cross-compile matrix (linux/darwin/windows × amd64/arm64)
- **Release workflow** (`release.yml`): GoReleaser v2 for GitHub Release + npm publish with [provenance](https://docs.npmjs.com/generating-provenance-statements) support
- **GoReleaser config** (`.goreleaser.yml`): CGO_ENABLED=0, ldflags version injection, changelog grouping
- **Linter config** (`.golangci.yml`): errcheck, gosimple, govet, staticcheck, gofmt, goimports, misspell, etc.

### npm Provenance

Following the pattern from [nacos-sdk-proto](https://github.com/nacos-group/nacos-sdk-proto), the npm publish step uses `id-token: write` permission and `--provenance` flag to enable [npm provenance](https://docs.npmjs.com/generating-provenance-statements), which displays a verified build source badge on npmjs.com.

### Required Secrets

| Secret | Purpose |
|--------|---------|
| `GITHUB_TOKEN` | Auto-provided, for GoReleaser |
| `NPM_TOKEN` | npm publish `@nacos-group/cli` |

Closes #22