### PR TITLE
fix(terminal): handle fmt.Sscanf return values to satisfy errcheck

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -50,13 +50,13 @@ Setup instructions:
 	Run: func(cmd *cobra.Command, args []string) {
 		switch args[0] {
 		case "bash":
-			cmd.Root().GenBashCompletion(os.Stdout)
+			_ = cmd.Root().GenBashCompletion(os.Stdout)
 		case "zsh":
-			cmd.Root().GenZshCompletion(os.Stdout)
+			_ = cmd.Root().GenZshCompletion(os.Stdout)
 		case "fish":
-			cmd.Root().GenFishCompletion(os.Stdout, true)
+			_ = cmd.Root().GenFishCompletion(os.Stdout, true)
 		case "powershell":
-			cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
+			_ = cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
 		}
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -274,7 +274,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&verbose, "verbose", false, "Enable verbose/debug output")
 
 	// Mark legacy server flag as deprecated but still functional
-	rootCmd.PersistentFlags().MarkDeprecated("server", "use --host and --port instead")
+	_ = rootCmd.PersistentFlags().MarkDeprecated("server", "use --host and --port instead")
 }
 
 func checkError(err error) {

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -1526,11 +1526,6 @@ func (t *Terminal) showConfigSetHelp() {
 	help.ConfigSet.FormatForTerminal()
 }
 
-func (t *Terminal) showSkillSyncHelp() {
-	fmt.Println("\033[33mskill-sync has been removed.\033[0m")
-	fmt.Println("\033[90mUse 'skill-get' to download skills.\033[0m")
-}
-
 // AgentSpec command help methods
 
 func (t *Terminal) showAgentSpecListHelp() {

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -583,25 +583,25 @@ func (t *Terminal) listSkills(args []string) {
 		} else if strings.HasPrefix(arg, "--page=") {
 			value := strings.TrimPrefix(arg, "--page=")
 			if value != "" {
-				fmt.Sscanf(value, "%d", &page)
+				_, _ = fmt.Sscanf(value, "%d", &page)
 			}
 		} else if arg == "--page" && i+1 < len(args) {
 			i++
-			fmt.Sscanf(args[i], "%d", &page)
+			_, _ = fmt.Sscanf(args[i], "%d", &page)
 		} else if arg == "--page=" && i+1 < len(args) {
 			i++
-			fmt.Sscanf(args[i], "%d", &page)
+			_, _ = fmt.Sscanf(args[i], "%d", &page)
 		} else if strings.HasPrefix(arg, "--size=") {
 			value := strings.TrimPrefix(arg, "--size=")
 			if value != "" {
-				fmt.Sscanf(value, "%d", &size)
+				_, _ = fmt.Sscanf(value, "%d", &size)
 			}
 		} else if arg == "--size" && i+1 < len(args) {
 			i++
-			fmt.Sscanf(args[i], "%d", &size)
+			_, _ = fmt.Sscanf(args[i], "%d", &size)
 		} else if arg == "--size=" && i+1 < len(args) {
 			i++
-			fmt.Sscanf(args[i], "%d", &size)
+			_, _ = fmt.Sscanf(args[i], "%d", &size)
 		}
 	}
 
@@ -1305,25 +1305,25 @@ func (t *Terminal) listConfigs(args []string) {
 		} else if strings.HasPrefix(arg, "--page=") {
 			value := strings.TrimPrefix(arg, "--page=")
 			if value != "" {
-				fmt.Sscanf(value, "%d", &page)
+				_, _ = fmt.Sscanf(value, "%d", &page)
 			}
 		} else if arg == "--page" && i+1 < len(args) {
 			i++
-			fmt.Sscanf(args[i], "%d", &page)
+			_, _ = fmt.Sscanf(args[i], "%d", &page)
 		} else if arg == "--page=" && i+1 < len(args) {
 			i++
-			fmt.Sscanf(args[i], "%d", &page)
+			_, _ = fmt.Sscanf(args[i], "%d", &page)
 		} else if strings.HasPrefix(arg, "--size=") {
 			value := strings.TrimPrefix(arg, "--size=")
 			if value != "" {
-				fmt.Sscanf(value, "%d", &size)
+				_, _ = fmt.Sscanf(value, "%d", &size)
 			}
 		} else if arg == "--size" && i+1 < len(args) {
 			i++
-			fmt.Sscanf(args[i], "%d", &size)
+			_, _ = fmt.Sscanf(args[i], "%d", &size)
 		} else if arg == "--size=" && i+1 < len(args) {
 			i++
-			fmt.Sscanf(args[i], "%d", &size)
+			_, _ = fmt.Sscanf(args[i], "%d", &size)
 		}
 	}
 
@@ -1579,19 +1579,19 @@ func (t *Terminal) listAgentSpecs(args []string) {
 		case strings.HasPrefix(arg, "--page="):
 			v := strings.TrimPrefix(arg, "--page=")
 			if v != "" {
-				fmt.Sscanf(v, "%d", &page)
+				_, _ = fmt.Sscanf(v, "%d", &page)
 			}
 		case arg == "--page" && i+1 < len(args):
 			i++
-			fmt.Sscanf(args[i], "%d", &page)
+			_, _ = fmt.Sscanf(args[i], "%d", &page)
 		case strings.HasPrefix(arg, "--size="):
 			v := strings.TrimPrefix(arg, "--size=")
 			if v != "" {
-				fmt.Sscanf(v, "%d", &size)
+				_, _ = fmt.Sscanf(v, "%d", &size)
 			}
 		case arg == "--size" && i+1 < len(args):
 			i++
-			fmt.Sscanf(args[i], "%d", &size)
+			_, _ = fmt.Sscanf(args[i], "%d", &size)
 		case strings.HasPrefix(arg, "--output="):
 			output = strings.TrimPrefix(arg, "--output=")
 		case arg == "--output" && i+1 < len(args):

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -6,11 +6,11 @@ import (
 
 func TestParseCommandArgs(t *testing.T) {
 	tests := []struct {
-		name          string
-		input         string
-		expectedCmd   string
-		expectedArgs  []string
-		description   string
+		name         string
+		input        string
+		expectedCmd  string
+		expectedArgs []string
+		description  string
 	}{
 		{
 			name:         "simple command without flags",
@@ -101,20 +101,20 @@ func TestParseCommandArgs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cmd, args := parseCommandArgs(tt.input)
-			
+
 			if cmd != tt.expectedCmd {
-				t.Errorf("parseCommandArgs(%q) cmd = %q, want %q\nTest: %s\nDescription: %s", 
+				t.Errorf("parseCommandArgs(%q) cmd = %q, want %q\nTest: %s\nDescription: %s",
 					tt.input, cmd, tt.expectedCmd, tt.name, tt.description)
 			}
-			
+
 			if len(args) != len(tt.expectedArgs) {
-				t.Errorf("parseCommandArgs(%q) args length = %d, want %d\nGot:  %v\nWant: %v\nTest: %s\nDescription: %s", 
+				t.Errorf("parseCommandArgs(%q) args length = %d, want %d\nGot:  %v\nWant: %v\nTest: %s\nDescription: %s",
 					tt.input, len(args), len(tt.expectedArgs), args, tt.expectedArgs, tt.name, tt.description)
 			}
-			
+
 			for i, arg := range args {
 				if i < len(tt.expectedArgs) && arg != tt.expectedArgs[i] {
-					t.Errorf("parseCommandArgs(%q) args[%d] = %q, want %q\nFull got:  %v\nFull want: %v\nTest: %s\nDescription: %s", 
+					t.Errorf("parseCommandArgs(%q) args[%d] = %q, want %q\nFull got:  %v\nFull want: %v\nTest: %s\nDescription: %s",
 						tt.input, i, arg, tt.expectedArgs[i], args, tt.expectedArgs, tt.name, tt.description)
 				}
 			}
@@ -124,22 +124,22 @@ func TestParseCommandArgs(t *testing.T) {
 
 func TestParseCommandArgsEdgeCases(t *testing.T) {
 	tests := []struct {
-		name          string
-		input         string
-		expectedCmd   string
-		expectedArgs  []string
+		name         string
+		input        string
+		expectedCmd  string
+		expectedArgs []string
 	}{
 		{
-			name:          "empty input",
-			input:         "",
-			expectedCmd:   "",
-			expectedArgs:  nil,
+			name:         "empty input",
+			input:        "",
+			expectedCmd:  "",
+			expectedArgs: nil,
 		},
 		{
-			name:          "whitespace only",
-			input:         "   ",
-			expectedCmd:   "",
-			expectedArgs:  nil,
+			name:         "whitespace only",
+			input:        "   ",
+			expectedCmd:  "",
+			expectedArgs: nil,
 		},
 		{
 			name:         "command only",
@@ -158,11 +158,11 @@ func TestParseCommandArgsEdgeCases(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cmd, args := parseCommandArgs(tt.input)
-			
+
 			if cmd != tt.expectedCmd {
 				t.Errorf("parseCommandArgs(%q) cmd = %q, want %q", tt.input, cmd, tt.expectedCmd)
 			}
-			
+
 			if len(args) != len(tt.expectedArgs) {
 				t.Errorf("parseCommandArgs(%q) args length = %d, want %d", tt.input, len(args), len(tt.expectedArgs))
 			}

--- a/internal/util/path.go
+++ b/internal/util/path.go
@@ -22,7 +22,7 @@ func ExpandTilde(path string) (string, error) {
 		}
 		return homeDir, nil
 	}
-	
+
 	if strings.HasPrefix(path, "~/") {
 		homeDir, err := os.UserHomeDir()
 		if err != nil {
@@ -30,7 +30,7 @@ func ExpandTilde(path string) (string, error) {
 		}
 		return filepath.Join(homeDir, path[2:]), nil
 	}
-	
+
 	// No expansion needed
 	return path, nil
 }


### PR DESCRIPTION
## Summary

- Handle `fmt.Sscanf` return values with `_, _ =` to satisfy the `errcheck` linter
- 16 occurrences in `internal/terminal/terminal.go` (page/size argument parsing)
- Parse failures are intentionally ignored — invalid input keeps the default value

Fixes #65