### PR TITLE
feat: add prompt management commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,6 +435,9 @@ nacos-cli prompt-draft my-prompt -f ./tpl.md --variables '[{"name":"topic"}]' --
 # With description and biz-tags (used only on first creation)
 nacos-cli prompt-draft my-prompt -f ./tpl.md --description "greeting prompt" --biz-tags "retail,finance"
 
+# Specify target version for the new draft
+nacos-cli prompt-draft my-prompt -f ./tpl.md --target-version 1.0.0
+
 # Terminal mode
 nacos> prompt-draft my-prompt -f ./template.md
 ```

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A powerful command-line tool for managing Nacos configuration center and AI skil
 - 💻 Interactive terminal mode with auto-completion
 - 🎯 Skill management - full lifecycle: upload → review → release, plus get/list/describe/sync
 - 🤖 AgentSpec management - full lifecycle: upload → review → release, plus get/list/describe
+- 💬 Prompt management - full lifecycle: draft → review → release, plus get/list/describe
 - 📝 Configuration management - list, get and set configurations
 - 🔄 Real-time skill synchronization with Nacos
 - 🌐 Namespace support for multi-environment management
@@ -367,6 +368,103 @@ nacos-cli skill-sync --all
 
 **Note**: `skill-sync` is only available in CLI mode, not in terminal mode.
 
+### Prompt Management
+
+Prompts follow a similar lifecycle to skills but use text templates instead of ZIP files:
+`draft` (editing) → `review` (reviewing → reviewed) → `release` (online).
+
+#### List Prompts
+
+```bash
+# CLI mode (pretty output by default)
+nacos-cli prompt-list -s 127.0.0.1:8848 -u nacos -p nacos
+
+# With filters
+nacos-cli prompt-list --name my-prompt --page 1 --size 20
+
+# Machine-readable output for scripts
+nacos-cli prompt-list --output json
+
+# Terminal mode
+nacos> prompt-list
+nacos> prompt-list --name my-prompt --output json
+```
+
+#### Describe Prompt
+
+```bash
+nacos-cli prompt-describe my-prompt
+nacos-cli prompt-describe my-prompt --output json
+
+# Terminal mode
+nacos> prompt-describe my-prompt
+```
+
+#### Get/Download Prompt
+
+```bash
+# Print latest prompt template to stdout
+nacos-cli prompt-get my-prompt
+
+# Save to file
+nacos-cli prompt-get my-prompt -o ./my-prompt.md
+
+# Get a specific version
+nacos-cli prompt-get my-prompt --version 1.0.0
+
+# Get via label
+nacos-cli prompt-get my-prompt --label stable
+
+# Terminal mode
+nacos> prompt-get my-prompt
+nacos> prompt-get my-prompt --version 1.0.0
+```
+
+#### Draft Prompt (create or update)
+
+```bash
+# Create/update a prompt draft from file
+nacos-cli prompt-draft my-prompt -f ./template.md
+
+# Create/update from stdin
+echo 'Hello {{name}}' | nacos-cli prompt-draft my-prompt
+
+# With variables and commit message
+nacos-cli prompt-draft my-prompt -f ./tpl.md --variables '[{"name":"topic"}]' --message "add topic var"
+
+# With description and biz-tags (used only on first creation)
+nacos-cli prompt-draft my-prompt -f ./tpl.md --description "greeting prompt" --biz-tags "retail,finance"
+
+# Terminal mode
+nacos> prompt-draft my-prompt -f ./template.md
+```
+
+#### Review Prompt
+
+```bash
+# Submit the current editing draft for review
+nacos-cli prompt-review my-prompt
+
+# Submit a specific version
+nacos-cli prompt-review my-prompt --version 0.0.1
+
+# Terminal mode
+nacos> prompt-review my-prompt
+```
+
+#### Release Prompt
+
+```bash
+# Release an approved version (marks it as latest)
+nacos-cli prompt-release my-prompt --version 1.0.0
+
+# Release without updating latest label
+nacos-cli prompt-release my-prompt --version 1.0.0 --update-latest=false
+
+# Terminal mode
+nacos> prompt-release my-prompt --version 1.0.0
+```
+
 ### Configuration Management
 
 #### List Configurations
@@ -509,6 +607,12 @@ nacos-cli/
 │   ├── review_agentspec.go    # agentspec-review
 │   ├── release_agentspec.go   # agentspec-release
 │   ├── publish_agentspec.go   # agentspec-publish (deprecated wrapper)
+│   ├── list_prompt.go         # prompt-list
+│   ├── describe_prompt.go     # prompt-describe
+│   ├── get_prompt.go          # prompt-get
+│   ├── draft_prompt.go        # prompt-draft
+│   ├── review_prompt.go       # prompt-review
+│   ├── release_prompt.go      # prompt-release
 │   ├── list_config.go         # config-list
 │   ├── get_config.go          # config-get
 │   ├── set_config.go          # config-set
@@ -518,6 +622,7 @@ nacos-cli/
 │   ├── client/                # Nacos client
 │   ├── skill/                 # Skill service
 │   ├── agentspec/             # AgentSpec service
+│   ├── prompt/                # Prompt service
 │   ├── sync/                  # Sync service
 │   ├── listener/              # Config listener
 │   ├── terminal/              # Interactive terminal implementation
@@ -572,6 +677,9 @@ MIT License
 
 ### Next Release
 
+- Added prompt management commands: `prompt-list`, `prompt-describe`, `prompt-get`,
+  `prompt-draft`, `prompt-review`, `prompt-release` — full lifecycle support for
+  Nacos AI prompt templates (draft → review → release)
 - Fixed `skill-upload` and `agentspec-upload` creating ZIP archives with an
   extra directory prefix, causing server-side extraction failures
   ([#46](https://github.com/nacos-group/nacos-cli/issues/46))

--- a/README.md
+++ b/README.md
@@ -438,6 +438,12 @@ nacos-cli prompt-draft my-prompt -f ./tpl.md --description "greeting prompt" --b
 # Specify target version for the new draft
 nacos-cli prompt-draft my-prompt -f ./tpl.md --target-version 1.0.0
 
+# Fork from an existing published version (server auto-increments version)
+nacos-cli prompt-draft my-prompt -f ./tpl.md --based-on-version 1.0.0
+
+# Fork and set explicit target version
+nacos-cli prompt-draft my-prompt -f ./tpl.md --based-on-version 1.0.0 --target-version 2.0.0
+
 # Terminal mode
 nacos> prompt-draft my-prompt -f ./template.md
 ```

--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ Prompts follow a similar lifecycle to skills but use text templates instead of Z
 # CLI mode (pretty output by default)
 nacos-cli prompt-list -s 127.0.0.1:8848 -u nacos -p nacos
 
-# With filters
+# Fuzzy search by name
 nacos-cli prompt-list --name my-prompt --page 1 --size 20
 
 # Machine-readable output for scripts
@@ -680,6 +680,10 @@ MIT License
 - Added prompt management commands: `prompt-list`, `prompt-describe`, `prompt-get`,
   `prompt-draft`, `prompt-review`, `prompt-release` — full lifecycle support for
   Nacos AI prompt templates (draft → review → release)
+- Prompt data models aligned with actual server API responses (bizTags as array,
+  nullable description, gmtModified timestamp, versionDetails structure)
+- `prompt-list --name` uses fuzzy search for convenience
+- `prompt-draft` auto-detects whether to create or update based on editing state
 - Fixed `skill-upload` and `agentspec-upload` creating ZIP archives with an
   extra directory prefix, causing server-side extraction failures
   ([#46](https://github.com/nacos-group/nacos-cli/issues/46))

--- a/cmd/describe_prompt.go
+++ b/cmd/describe_prompt.go
@@ -64,8 +64,8 @@ func renderPromptDetailPretty(d *prompt.PromptDetail) {
 	}
 	fmt.Printf("Prompt: %s\n", key)
 	fmt.Println(separator)
-	if d.Description != "" {
-		fmt.Printf("  description: %s\n", d.Description)
+	if d.Description != nil && *d.Description != "" {
+		fmt.Printf("  description: %s\n", *d.Description)
 	}
 
 	// Governance metadata block.
@@ -81,14 +81,14 @@ func renderPromptDetailPretty(d *prompt.PromptDetail) {
 	)
 
 	var meta []string
-	if d.BizTags != "" {
-		meta = append(meta, "bizTags="+d.BizTags)
+	if len(d.BizTags) > 0 {
+		meta = append(meta, "bizTags="+strings.Join(d.BizTags, ","))
 	}
 	if d.Owner != "" {
 		meta = append(meta, "owner="+d.Owner)
 	}
-	if d.UpdateTime != nil && *d.UpdateTime > 0 {
-		meta = append(meta, "updated="+time.UnixMilli(*d.UpdateTime).Format("2006-01-02 15:04:05"))
+	if d.GmtModified != nil && *d.GmtModified > 0 {
+		meta = append(meta, "updated="+time.UnixMilli(*d.GmtModified).Format("2006-01-02 15:04:05"))
 	}
 	if d.DownloadCount != nil && *d.DownloadCount > 0 {
 		meta = append(meta, fmt.Sprintf("downloads=%d", *d.DownloadCount))
@@ -103,12 +103,12 @@ func renderPromptDetailPretty(d *prompt.PromptDetail) {
 	// Version table.
 	fmt.Println()
 	fmt.Println("Versions:")
-	if len(d.Versions) == 0 {
+	if len(d.VersionDetails) == 0 {
 		fmt.Println("  (none)")
 		return
 	}
 
-	versions := sortedPromptVersions(d.Versions)
+	versions := sortedPromptVersions(d.VersionDetails)
 	widths := computePromptVersionColumnWidths(versions)
 	header := fmt.Sprintf("  %-*s  %-*s  %-*s  %-*s  %s",
 		widths.version, "VERSION",
@@ -119,12 +119,16 @@ func renderPromptDetailPretty(d *prompt.PromptDetail) {
 	fmt.Println(header)
 	fmt.Println("  " + util.SeparatorLine(len(header)-2, asciiMode))
 	for _, v := range versions {
+		commitMsg := ""
+		if v.CommitMsg != nil {
+			commitMsg = *v.CommitMsg
+		}
 		fmt.Printf("  %-*s  %-*s  %-*s  %-*s  %s\n",
 			widths.version, v.Version,
 			widths.status, dashIfEmpty(v.Status),
-			widths.author, dashIfEmpty(v.Author),
-			widths.updated, promptFormatTimestamp(v.UpdateTime),
-			truncateDesc(strings.ReplaceAll(v.CommitMsg, "\n", " "), 60),
+			widths.author, dashIfEmpty(v.SrcUser),
+			widths.updated, promptFormatTimestamp(v.GmtModified),
+			truncateDesc(strings.ReplaceAll(commitMsg, "\n", " "), 60),
 		)
 	}
 }
@@ -145,7 +149,7 @@ func computePromptVersionColumnWidths(versions []prompt.PromptVersionSummary) pr
 		if n := len(v.Status); n > w.status {
 			w.status = n
 		}
-		if n := len(v.Author); n > w.author {
+		if n := len(v.SrcUser); n > w.author {
 			w.author = n
 		}
 	}
@@ -167,11 +171,8 @@ func sortedPromptVersions(versions []prompt.PromptVersionSummary) []prompt.Promp
 }
 
 func promptVersionSortKey(v prompt.PromptVersionSummary) int64 {
-	if v.UpdateTime != nil {
-		return *v.UpdateTime
-	}
-	if v.CreateTime != nil {
-		return *v.CreateTime
+	if v.GmtModified != nil {
+		return *v.GmtModified
 	}
 	return 0
 }

--- a/cmd/describe_prompt.go
+++ b/cmd/describe_prompt.go
@@ -1,0 +1,184 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/nacos-group/nacos-cli/internal/help"
+	"github.com/nacos-group/nacos-cli/internal/prompt"
+	"github.com/nacos-group/nacos-cli/internal/util"
+	"github.com/spf13/cobra"
+)
+
+var promptDescribeOutput string
+
+var describePromptCmd = &cobra.Command{
+	Use:   "prompt-describe [promptKey]",
+	Short: "Show detailed info of a prompt, including version list and per-version status",
+	Long:  help.PromptDescribe.FormatForCLI("nacos-cli"),
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		nacosClient := mustNewNacosClient()
+		promptService := prompt.NewPromptService(nacosClient)
+
+		detail, err := promptService.DescribePrompt(args[0])
+		checkError(err)
+
+		switch strings.ToLower(promptDescribeOutput) {
+		case "json":
+			renderPromptDetailJSON(detail)
+		case "", "pretty":
+			renderPromptDetailPretty(detail)
+		default:
+			fmt.Fprintf(os.Stderr, "Error: unsupported --output value %q (expect 'pretty' or 'json')\n", promptDescribeOutput)
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	describePromptCmd.Flags().StringVar(&promptDescribeOutput, "output", "pretty", "Output format: pretty | json")
+	rootCmd.AddCommand(describePromptCmd)
+}
+
+func renderPromptDetailJSON(d *prompt.PromptDetail) {
+	data, err := json.MarshalIndent(d, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: failed to encode JSON: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println(string(data))
+}
+
+func renderPromptDetailPretty(d *prompt.PromptDetail) {
+	asciiMode := os.Getenv("NO_UNICODE_OUTPUT") != ""
+	separator := util.SeparatorLine(79, asciiMode)
+
+	key := d.PromptKey
+	if key == "" {
+		key = d.Name
+	}
+	fmt.Printf("Prompt: %s\n", key)
+	fmt.Println(separator)
+	if d.Description != "" {
+		fmt.Printf("  description: %s\n", d.Description)
+	}
+
+	// Governance metadata block.
+	onlineCnt := "-"
+	if d.OnlineCnt != nil {
+		onlineCnt = fmt.Sprintf("%d", *d.OnlineCnt)
+	}
+	fmt.Printf("  latest=%s  editing=%s  reviewing=%s  online=%s\n",
+		dashIfEmpty(d.Labels["latest"]),
+		dashIfEmpty(d.EditingVersion),
+		dashIfEmpty(d.ReviewingVersion),
+		onlineCnt,
+	)
+
+	var meta []string
+	if d.BizTags != "" {
+		meta = append(meta, "bizTags="+d.BizTags)
+	}
+	if d.Owner != "" {
+		meta = append(meta, "owner="+d.Owner)
+	}
+	if d.UpdateTime != nil && *d.UpdateTime > 0 {
+		meta = append(meta, "updated="+time.UnixMilli(*d.UpdateTime).Format("2006-01-02 15:04:05"))
+	}
+	if d.DownloadCount != nil && *d.DownloadCount > 0 {
+		meta = append(meta, fmt.Sprintf("downloads=%d", *d.DownloadCount))
+	}
+	if len(meta) > 0 {
+		fmt.Println("  " + strings.Join(meta, "  "))
+	}
+	if extra := extraLabels(d.Labels); len(extra) > 0 {
+		fmt.Println("  labels: " + strings.Join(extra, ", "))
+	}
+
+	// Version table.
+	fmt.Println()
+	fmt.Println("Versions:")
+	if len(d.Versions) == 0 {
+		fmt.Println("  (none)")
+		return
+	}
+
+	versions := sortedPromptVersions(d.Versions)
+	widths := computePromptVersionColumnWidths(versions)
+	header := fmt.Sprintf("  %-*s  %-*s  %-*s  %-*s  %s",
+		widths.version, "VERSION",
+		widths.status, "STATUS",
+		widths.author, "AUTHOR",
+		widths.updated, "UPDATED",
+		"COMMIT")
+	fmt.Println(header)
+	fmt.Println("  " + util.SeparatorLine(len(header)-2, asciiMode))
+	for _, v := range versions {
+		fmt.Printf("  %-*s  %-*s  %-*s  %-*s  %s\n",
+			widths.version, v.Version,
+			widths.status, dashIfEmpty(v.Status),
+			widths.author, dashIfEmpty(v.Author),
+			widths.updated, promptFormatTimestamp(v.UpdateTime),
+			truncateDesc(strings.ReplaceAll(v.CommitMsg, "\n", " "), 60),
+		)
+	}
+}
+
+type promptVersionColumnWidths struct {
+	version int
+	status  int
+	author  int
+	updated int
+}
+
+func computePromptVersionColumnWidths(versions []prompt.PromptVersionSummary) promptVersionColumnWidths {
+	w := promptVersionColumnWidths{version: 7, status: 9, author: 8, updated: 19}
+	for _, v := range versions {
+		if n := len(v.Version); n > w.version {
+			w.version = n
+		}
+		if n := len(v.Status); n > w.status {
+			w.status = n
+		}
+		if n := len(v.Author); n > w.author {
+			w.author = n
+		}
+	}
+	return w
+}
+
+func sortedPromptVersions(versions []prompt.PromptVersionSummary) []prompt.PromptVersionSummary {
+	out := make([]prompt.PromptVersionSummary, len(versions))
+	copy(out, versions)
+	sort.SliceStable(out, func(i, j int) bool {
+		ti := promptVersionSortKey(out[i])
+		tj := promptVersionSortKey(out[j])
+		if ti != tj {
+			return ti > tj
+		}
+		return out[i].Version > out[j].Version
+	})
+	return out
+}
+
+func promptVersionSortKey(v prompt.PromptVersionSummary) int64 {
+	if v.UpdateTime != nil {
+		return *v.UpdateTime
+	}
+	if v.CreateTime != nil {
+		return *v.CreateTime
+	}
+	return 0
+}
+
+func promptFormatTimestamp(ts *int64) string {
+	if ts == nil || *ts <= 0 {
+		return "-"
+	}
+	return time.UnixMilli(*ts).Format("2006-01-02 15:04:05")
+}

--- a/cmd/draft_prompt.go
+++ b/cmd/draft_prompt.go
@@ -17,6 +17,7 @@ var (
 	promptDraftDescription   string
 	promptDraftBizTags       string
 	promptDraftTargetVersion string
+	promptDraftBasedOn       string
 )
 
 var draftPromptCmd = &cobra.Command{
@@ -35,7 +36,8 @@ var draftPromptCmd = &cobra.Command{
 
 		fmt.Printf("Creating/updating prompt draft: %s...\n", promptKey)
 		err := promptService.Draft(promptKey, template, promptDraftVariables,
-			promptDraftMessage, promptDraftDescription, promptDraftBizTags, promptDraftTargetVersion)
+			promptDraftMessage, promptDraftDescription, promptDraftBizTags,
+			promptDraftTargetVersion, promptDraftBasedOn)
 		checkError(err)
 
 		fmt.Printf("Prompt draft saved successfully!\n")
@@ -50,6 +52,7 @@ func init() {
 	draftPromptCmd.Flags().StringVar(&promptDraftDescription, "description", "", "Prompt description (used when creating new prompt)")
 	draftPromptCmd.Flags().StringVar(&promptDraftBizTags, "biz-tags", "", "Business tags (used when creating new prompt)")
 	draftPromptCmd.Flags().StringVar(&promptDraftTargetVersion, "target-version", "", "Target version for the new draft (e.g. 1.0.0)")
+	draftPromptCmd.Flags().StringVar(&promptDraftBasedOn, "based-on-version", "", "Fork from an existing version (e.g. 1.0.0)")
 	rootCmd.AddCommand(draftPromptCmd)
 }
 

--- a/cmd/draft_prompt.go
+++ b/cmd/draft_prompt.go
@@ -11,11 +11,12 @@ import (
 )
 
 var (
-	promptDraftFile        string
-	promptDraftVariables   string
-	promptDraftMessage     string
-	promptDraftDescription string
-	promptDraftBizTags     string
+	promptDraftFile          string
+	promptDraftVariables     string
+	promptDraftMessage       string
+	promptDraftDescription   string
+	promptDraftBizTags       string
+	promptDraftTargetVersion string
 )
 
 var draftPromptCmd = &cobra.Command{
@@ -34,7 +35,7 @@ var draftPromptCmd = &cobra.Command{
 
 		fmt.Printf("Creating/updating prompt draft: %s...\n", promptKey)
 		err := promptService.Draft(promptKey, template, promptDraftVariables,
-			promptDraftMessage, promptDraftDescription, promptDraftBizTags)
+			promptDraftMessage, promptDraftDescription, promptDraftBizTags, promptDraftTargetVersion)
 		checkError(err)
 
 		fmt.Printf("Prompt draft saved successfully!\n")
@@ -48,6 +49,7 @@ func init() {
 	draftPromptCmd.Flags().StringVar(&promptDraftMessage, "message", "", "Commit message for this draft")
 	draftPromptCmd.Flags().StringVar(&promptDraftDescription, "description", "", "Prompt description (used when creating new prompt)")
 	draftPromptCmd.Flags().StringVar(&promptDraftBizTags, "biz-tags", "", "Business tags (used when creating new prompt)")
+	draftPromptCmd.Flags().StringVar(&promptDraftTargetVersion, "target-version", "", "Target version for the new draft (e.g. 1.0.0)")
 	rootCmd.AddCommand(draftPromptCmd)
 }
 

--- a/cmd/draft_prompt.go
+++ b/cmd/draft_prompt.go
@@ -1,0 +1,81 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/nacos-group/nacos-cli/internal/help"
+	"github.com/nacos-group/nacos-cli/internal/prompt"
+	"github.com/spf13/cobra"
+)
+
+var (
+	promptDraftFile        string
+	promptDraftVariables   string
+	promptDraftMessage     string
+	promptDraftDescription string
+	promptDraftBizTags     string
+)
+
+var draftPromptCmd = &cobra.Command{
+	Use:   "prompt-draft [promptKey]",
+	Short: "Create or update a prompt draft",
+	Long:  help.PromptDraft.FormatForCLI("nacos-cli"),
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		promptKey := args[0]
+
+		// Read template content from file or stdin
+		template := readPromptTemplate()
+
+		nacosClient := mustNewNacosClient()
+		promptService := prompt.NewPromptService(nacosClient)
+
+		fmt.Printf("Creating/updating prompt draft: %s...\n", promptKey)
+		err := promptService.Draft(promptKey, template, promptDraftVariables,
+			promptDraftMessage, promptDraftDescription, promptDraftBizTags)
+		checkError(err)
+
+		fmt.Printf("Prompt draft saved successfully!\n")
+		fmt.Printf("  Tip: Use 'prompt-review %s' to submit the draft for review.\n", promptKey)
+	},
+}
+
+func init() {
+	draftPromptCmd.Flags().StringVarP(&promptDraftFile, "file", "f", "", "Path to template file (default: read from stdin)")
+	draftPromptCmd.Flags().StringVar(&promptDraftVariables, "variables", "", "Variables JSON array")
+	draftPromptCmd.Flags().StringVar(&promptDraftMessage, "message", "", "Commit message for this draft")
+	draftPromptCmd.Flags().StringVar(&promptDraftDescription, "description", "", "Prompt description (used when creating new prompt)")
+	draftPromptCmd.Flags().StringVar(&promptDraftBizTags, "biz-tags", "", "Business tags (used when creating new prompt)")
+	rootCmd.AddCommand(draftPromptCmd)
+}
+
+func readPromptTemplate() string {
+	if promptDraftFile != "" {
+		data, err := os.ReadFile(promptDraftFile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: failed to read file %s: %v\n", promptDraftFile, err)
+			os.Exit(1)
+		}
+		return string(data)
+	}
+
+	// Read from stdin
+	stat, _ := os.Stdin.Stat()
+	if (stat.Mode() & os.ModeCharDevice) != 0 {
+		fmt.Fprintf(os.Stderr, "Error: no template provided. Use --file or pipe content via stdin.\n")
+		os.Exit(1)
+	}
+
+	data, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: failed to read stdin: %v\n", err)
+		os.Exit(1)
+	}
+	if len(data) == 0 {
+		fmt.Fprintf(os.Stderr, "Error: empty template. Provide content via --file or stdin.\n")
+		os.Exit(1)
+	}
+	return string(data)
+}

--- a/cmd/get_prompt.go
+++ b/cmd/get_prompt.go
@@ -72,7 +72,7 @@ func savePromptToFile(p *prompt.ClientPrompt, outputPath string) {
 	// Save variables as a separate JSON file if present
 	if len(p.Variables) > 0 && string(p.Variables) != "null" {
 		varsPath := outputPath + ".variables.json"
-		prettyVars, err := json.MarshalIndent(json.RawMessage(p.Variables), "", "  ")
+		prettyVars, err := json.MarshalIndent(p.Variables, "", "  ")
 		if err == nil {
 			if err := os.WriteFile(varsPath, prettyVars, 0644); err == nil {
 				fmt.Printf("  Variables: %s\n", varsPath)

--- a/cmd/get_prompt.go
+++ b/cmd/get_prompt.go
@@ -1,0 +1,82 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/nacos-group/nacos-cli/internal/help"
+	"github.com/nacos-group/nacos-cli/internal/prompt"
+	"github.com/spf13/cobra"
+)
+
+var (
+	getPromptOutput  string
+	getPromptVersion string
+	getPromptLabel   string
+)
+
+var getPromptCmd = &cobra.Command{
+	Use:   "prompt-get [promptKey]",
+	Short: "Get a prompt template from Nacos",
+	Long:  help.PromptGet.FormatForCLI("nacos-cli"),
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		promptKey := args[0]
+
+		nacosClient := mustNewNacosClient()
+		promptService := prompt.NewPromptService(nacosClient)
+
+		result, err := promptService.GetPrompt(promptKey, getPromptVersion, getPromptLabel)
+		checkError(err)
+
+		if getPromptOutput == "" {
+			// Print to stdout
+			printPromptContent(result)
+		} else {
+			// Save to file
+			savePromptToFile(result, getPromptOutput)
+		}
+	},
+}
+
+func init() {
+	getPromptCmd.Flags().StringVarP(&getPromptOutput, "output", "o", "", "Output file path (default: print to stdout)")
+	getPromptCmd.Flags().StringVar(&getPromptVersion, "version", "", "Specific version to get")
+	getPromptCmd.Flags().StringVar(&getPromptLabel, "label", "", "Route label to resolve version (e.g. latest, stable)")
+	rootCmd.AddCommand(getPromptCmd)
+}
+
+func printPromptContent(p *prompt.ClientPrompt) {
+	fmt.Printf("# Prompt: %s (version: %s)\n\n", p.PromptKey, p.Version)
+	fmt.Println(p.Template)
+
+	if len(p.Variables) > 0 && string(p.Variables) != "null" {
+		fmt.Printf("\n---\nVariables: %s\n", string(p.Variables))
+	}
+}
+
+func savePromptToFile(p *prompt.ClientPrompt, outputPath string) {
+	content := p.Template
+
+	if err := os.WriteFile(outputPath, []byte(content), 0644); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: failed to write file %s: %v\n", outputPath, err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Prompt saved successfully!\n")
+	fmt.Printf("  Key: %s\n", p.PromptKey)
+	fmt.Printf("  Version: %s\n", p.Version)
+	fmt.Printf("  Location: %s\n", outputPath)
+
+	// Save variables as a separate JSON file if present
+	if len(p.Variables) > 0 && string(p.Variables) != "null" {
+		varsPath := outputPath + ".variables.json"
+		prettyVars, err := json.MarshalIndent(json.RawMessage(p.Variables), "", "  ")
+		if err == nil {
+			if err := os.WriteFile(varsPath, prettyVars, 0644); err == nil {
+				fmt.Printf("  Variables: %s\n", varsPath)
+			}
+		}
+	}
+}

--- a/cmd/list_prompt.go
+++ b/cmd/list_prompt.go
@@ -1,0 +1,147 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/nacos-group/nacos-cli/internal/help"
+	"github.com/nacos-group/nacos-cli/internal/prompt"
+	"github.com/nacos-group/nacos-cli/internal/util"
+	"github.com/spf13/cobra"
+)
+
+var (
+	promptListPage   int
+	promptListSize   int
+	promptListName   string
+	promptListOutput string
+)
+
+var listPromptCmd = &cobra.Command{
+	Use:   "prompt-list",
+	Short: "List all prompts",
+	Long:  help.PromptList.FormatForCLI("nacos-cli"),
+	Run: func(cmd *cobra.Command, args []string) {
+		nacosClient := mustNewNacosClient()
+		promptService := prompt.NewPromptService(nacosClient)
+
+		prompts, totalCount, err := promptService.ListPrompts(promptListName, promptListPage, promptListSize)
+		checkError(err)
+
+		switch strings.ToLower(promptListOutput) {
+		case "json":
+			renderPromptListJSON(prompts, totalCount, promptListPage, promptListSize)
+		case "", "pretty":
+			renderPromptListPretty(prompts, totalCount, promptListPage, promptListSize)
+		default:
+			fmt.Fprintf(os.Stderr, "Error: unsupported --output value %q (expect 'pretty' or 'json')\n", promptListOutput)
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	listPromptCmd.Flags().IntVar(&promptListPage, "page", 1, "Page number (default: 1)")
+	listPromptCmd.Flags().IntVar(&promptListSize, "size", 20, "Page size (default: 20)")
+	listPromptCmd.Flags().StringVar(&promptListName, "name", "", "Filter by prompt key (exact match)")
+	listPromptCmd.Flags().StringVar(&promptListOutput, "output", "pretty", "Output format: pretty | json")
+	rootCmd.AddCommand(listPromptCmd)
+}
+
+func renderPromptListJSON(prompts []prompt.PromptListItem, totalCount, pageNo, pageSize int) {
+	totalPages := 0
+	if pageSize > 0 {
+		totalPages = (totalCount + pageSize - 1) / pageSize
+	}
+	payload := map[string]interface{}{
+		"totalCount": totalCount,
+		"pageNo":     pageNo,
+		"pageSize":   pageSize,
+		"totalPages": totalPages,
+		"pageItems":  prompts,
+	}
+	data, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: failed to encode JSON: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println(string(data))
+}
+
+func renderPromptListPretty(prompts []prompt.PromptListItem, totalCount, pageNo, pageSize int) {
+	totalPages := 0
+	if pageSize > 0 {
+		totalPages = (totalCount + pageSize - 1) / pageSize
+	}
+
+	if len(prompts) == 0 {
+		if totalPages == 0 {
+			fmt.Println("No prompts found")
+		} else {
+			fmt.Printf("Page %d is out of range (Total: %d items, Total pages: %d)\n", pageNo, totalCount, totalPages)
+		}
+		return
+	}
+
+	asciiMode := os.Getenv("NO_UNICODE_OUTPUT") != ""
+	separator := util.SeparatorLine(79, asciiMode)
+
+	fmt.Printf("Prompt List (Page: %d/%d, Total: %d)\n", pageNo, totalPages, totalCount)
+	fmt.Println(separator)
+	for i, p := range prompts {
+		printPromptListItem((pageNo-1)*pageSize+i+1, p)
+	}
+}
+
+func printPromptListItem(idx int, p prompt.PromptListItem) {
+	key := p.PromptKey
+	if key == "" {
+		key = p.Name
+	}
+	if p.Description != "" {
+		desc := truncateDesc(p.Description, defaultDescLimit)
+		fmt.Printf("%3d. %s - %s\n", idx, key, desc)
+	} else {
+		fmt.Printf("%3d. %s\n", idx, key)
+	}
+
+	// Line 2: version governance signals.
+	onlineCnt := "-"
+	if p.OnlineCnt != nil {
+		onlineCnt = fmt.Sprintf("%d", *p.OnlineCnt)
+	}
+	fmt.Printf("     latest=%s  editing=%s  reviewing=%s  online=%s\n",
+		dashIfEmpty(p.Labels["latest"]),
+		dashIfEmpty(p.EditingVersion),
+		dashIfEmpty(p.ReviewingVersion),
+		onlineCnt,
+	)
+
+	// Line 3: governance metadata.
+	var meta []string
+	if p.BizTags != "" {
+		meta = append(meta, "bizTags="+p.BizTags)
+	}
+	if p.Owner != "" {
+		meta = append(meta, "owner="+p.Owner)
+	}
+	if p.UpdateTime != nil && *p.UpdateTime > 0 {
+		meta = append(meta, "updated="+time.UnixMilli(*p.UpdateTime).Format("2006-01-02 15:04:05"))
+	}
+	if p.DownloadCount != nil && *p.DownloadCount > 0 {
+		meta = append(meta, fmt.Sprintf("downloads=%d", *p.DownloadCount))
+	}
+	if len(meta) > 0 {
+		fmt.Println("     " + strings.Join(meta, "  "))
+	}
+
+	// Line 4: extra labels beyond "latest".
+	if extra := extraLabels(p.Labels); len(extra) > 0 {
+		fmt.Println("     labels: " + strings.Join(extra, ", "))
+	}
+}
+
+

--- a/cmd/list_prompt.go
+++ b/cmd/list_prompt.go
@@ -143,5 +143,3 @@ func printPromptListItem(idx int, p prompt.PromptListItem) {
 		fmt.Println("     labels: " + strings.Join(extra, ", "))
 	}
 }
-
-

--- a/cmd/list_prompt.go
+++ b/cmd/list_prompt.go
@@ -101,8 +101,8 @@ func printPromptListItem(idx int, p prompt.PromptListItem) {
 	if key == "" {
 		key = p.Name
 	}
-	if p.Description != "" {
-		desc := truncateDesc(p.Description, defaultDescLimit)
+	if p.Description != nil && *p.Description != "" {
+		desc := truncateDesc(*p.Description, defaultDescLimit)
 		fmt.Printf("%3d. %s - %s\n", idx, key, desc)
 	} else {
 		fmt.Printf("%3d. %s\n", idx, key)
@@ -122,14 +122,14 @@ func printPromptListItem(idx int, p prompt.PromptListItem) {
 
 	// Line 3: governance metadata.
 	var meta []string
-	if p.BizTags != "" {
-		meta = append(meta, "bizTags="+p.BizTags)
+	if len(p.BizTags) > 0 {
+		meta = append(meta, "bizTags="+strings.Join(p.BizTags, ","))
 	}
 	if p.Owner != "" {
 		meta = append(meta, "owner="+p.Owner)
 	}
-	if p.UpdateTime != nil && *p.UpdateTime > 0 {
-		meta = append(meta, "updated="+time.UnixMilli(*p.UpdateTime).Format("2006-01-02 15:04:05"))
+	if p.GmtModified != nil && *p.GmtModified > 0 {
+		meta = append(meta, "updated="+time.UnixMilli(*p.GmtModified).Format("2006-01-02 15:04:05"))
 	}
 	if p.DownloadCount != nil && *p.DownloadCount > 0 {
 		meta = append(meta, fmt.Sprintf("downloads=%d", *p.DownloadCount))

--- a/cmd/release_prompt.go
+++ b/cmd/release_prompt.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/nacos-group/nacos-cli/internal/help"
+	"github.com/nacos-group/nacos-cli/internal/prompt"
+	"github.com/spf13/cobra"
+)
+
+var (
+	promptReleaseVersion      string
+	promptReleaseUpdateLatest bool
+)
+
+var releasePromptCmd = &cobra.Command{
+	Use:   "prompt-release [promptKey]",
+	Short: "Release an approved prompt version (reviewing -> online)",
+	Long:  help.PromptRelease.FormatForCLI("nacos-cli"),
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		if promptReleaseVersion == "" {
+			fmt.Fprintf(os.Stderr, "Error: --version is required for prompt-release\n")
+			os.Exit(1)
+		}
+
+		nacosClient := mustNewNacosClient()
+		promptService := prompt.NewPromptService(nacosClient)
+
+		promptKey := args[0]
+		fmt.Printf("Releasing prompt: %s@%s (updateLatest=%v)...\n", promptKey, promptReleaseVersion, promptReleaseUpdateLatest)
+		if err := promptService.Publish(promptKey, promptReleaseVersion, promptReleaseUpdateLatest); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: failed to release prompt '%s@%s': %v\n", promptKey, promptReleaseVersion, err)
+			maybePrintReleaseRetryHint(err, "prompt", promptKey)
+			os.Exit(1)
+		}
+		fmt.Printf("Prompt released successfully!\n")
+		fmt.Printf("  %s@%s is now online.\n", promptKey, promptReleaseVersion)
+	},
+}
+
+func init() {
+	releasePromptCmd.Flags().StringVar(&promptReleaseVersion, "version", "", "Required. Approved (reviewing) version to release")
+	releasePromptCmd.Flags().BoolVar(&promptReleaseUpdateLatest, "update-latest", true, "Whether to update the 'latest' label to the released version")
+	rootCmd.AddCommand(releasePromptCmd)
+}

--- a/cmd/review_prompt.go
+++ b/cmd/review_prompt.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/nacos-group/nacos-cli/internal/help"
+	"github.com/nacos-group/nacos-cli/internal/prompt"
+	"github.com/spf13/cobra"
+)
+
+var promptReviewVersion string
+
+var reviewPromptCmd = &cobra.Command{
+	Use:   "prompt-review [promptKey]",
+	Short: "Submit a prompt draft for review (editing -> reviewing)",
+	Long:  help.PromptReview.FormatForCLI("nacos-cli"),
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		nacosClient := mustNewNacosClient()
+		promptService := prompt.NewPromptService(nacosClient)
+
+		promptKey := args[0]
+		fmt.Printf("Submitting prompt for review: %s...\n", promptKey)
+		if err := promptService.Submit(promptKey, promptReviewVersion); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: failed to submit prompt '%s' for review: %v\n", promptKey, err)
+			os.Exit(1)
+		}
+		fmt.Printf("Prompt submitted for review successfully!\n")
+		fmt.Printf("  Tip: After the review passes, run 'prompt-release %s --version <ver>' to publish it online.\n", promptKey)
+	},
+}
+
+func init() {
+	reviewPromptCmd.Flags().StringVar(&promptReviewVersion, "version", "", "Specific draft version to submit")
+	rootCmd.AddCommand(reviewPromptCmd)
+}

--- a/internal/help/help.go
+++ b/internal/help/help.go
@@ -267,6 +267,139 @@ var (
 		Examples:    []string{},
 	}
 
+	PromptList = CommandHelp{
+		Command:     "prompt-list",
+		Description: "List all prompts with governance info (latest/editing/reviewing/onlineCnt/labels/updateTime).",
+		Parameters: []string{
+			"--name string   Filter by prompt key (exact match)",
+			"--page int      Page number (default: 1)",
+			"--size int      Page size (default: 20)",
+			"--output string Output format: pretty | json (default: pretty)",
+		},
+		Examples: []string{
+			"# List all prompts (human-readable)",
+			"prompt-list",
+			"",
+			"# Search by prompt key",
+			"prompt-list --name \"my-prompt\"",
+			"",
+			"# With pagination",
+			"prompt-list --page 2 --size 10",
+			"",
+			"# Machine-readable JSON",
+			"prompt-list --output json",
+		},
+	}
+
+	PromptDescribe = CommandHelp{
+		Command:     "prompt-describe",
+		Description: "Show detailed info of a prompt, including governance metadata and the full version list with per-version status.",
+		Parameters: []string{
+			"promptKey       Required. Prompt key to describe",
+			"--output string Output format: pretty | json (default: pretty)",
+		},
+		Examples: []string{
+			"# Show prompt detail in human-readable form",
+			"prompt-describe my-prompt",
+			"",
+			"# Machine-readable JSON",
+			"prompt-describe my-prompt --output json",
+		},
+	}
+
+	PromptGet = CommandHelp{
+		Command:     "prompt-get",
+		Description: "Get a prompt template from Nacos and save it locally or print to stdout.",
+		Parameters: []string{
+			"promptKey       Required. Prompt key to get",
+			"-o, --output    Output file path (default: print to stdout)",
+			"--version       Specific version to get",
+			"--label         Route label to resolve version (e.g. latest, stable)",
+		},
+		Examples: []string{
+			"# Print the latest prompt template to stdout",
+			"prompt-get my-prompt",
+			"",
+			"# Save to file",
+			"prompt-get my-prompt -o ./my-prompt.md",
+			"",
+			"# Get a specific version",
+			"prompt-get my-prompt --version 1.0.0",
+			"",
+			"# Get via label",
+			"prompt-get my-prompt --label stable",
+		},
+	}
+
+	PromptDraft = CommandHelp{
+		Command:     "prompt-draft",
+		Description: "Create or update a prompt draft. Automatically detects whether to create a new draft or update an existing one.",
+		Parameters: []string{
+			"promptKey       Required. Prompt key",
+			"-f, --file      Path to template file (default: read from stdin)",
+			"--variables     Variables JSON (e.g. '[{\"name\":\"topic\",\"defaultValue\":\"AI\"}]')",
+			"--message       Commit message for this draft",
+			"--description   Prompt description (only used when creating new prompt)",
+			"--biz-tags      Business tags (only used when creating new prompt)",
+		},
+		Examples: []string{
+			"# Create/update a prompt draft from file",
+			"prompt-draft my-prompt -f ./template.md",
+			"",
+			"# Create/update from stdin",
+			"echo 'Hello {{name}}' | prompt-draft my-prompt",
+			"",
+			"# With variables and commit message",
+			"prompt-draft my-prompt -f ./tpl.md --variables '[{\"name\":\"topic\"}]' --message \"add topic var\"",
+			"",
+			"Note:",
+			"  - If no editing draft exists, a new one is created",
+			"  - If an editing draft already exists, it is updated",
+			"  - After draft, use prompt-review to submit for review",
+		},
+	}
+
+	PromptReview = CommandHelp{
+		Command:     "prompt-review",
+		Description: "Submit a prompt draft for review (moves editing -> reviewing).",
+		Parameters: []string{
+			"promptKey       Required. Prompt key to submit for review",
+			"--version       Optional. Specific draft version to submit",
+		},
+		Examples: []string{
+			"# Submit the current draft for review",
+			"prompt-review my-prompt",
+			"",
+			"# Submit a specific version",
+			"prompt-review my-prompt --version 0.0.1",
+			"",
+			"Note:",
+			"  - If --version is omitted, the server submits the current editingVersion",
+			"  - After review passes, use prompt-release to publish it online",
+		},
+	}
+
+	PromptRelease = CommandHelp{
+		Command:     "prompt-release",
+		Description: "Release (publish) an approved prompt version to make it online.",
+		Parameters: []string{
+			"promptKey            Required. Prompt key to release",
+			"--version            Required. Approved (reviewing) version to release",
+			"--update-latest      Whether to update the 'latest' label (default: true)",
+		},
+		Examples: []string{
+			"# Release an approved version and mark it as latest",
+			"prompt-release my-prompt --version 1.0.0",
+			"",
+			"# Release without updating the latest label",
+			"prompt-release my-prompt --version 1.0.0 --update-latest=false",
+			"",
+			"Note:",
+			"  - The target version must be in 'reviewing' state (approved by pipeline)",
+			"  - Flow: prompt-draft -> prompt-review -> prompt-release",
+		},
+	}
+
 	AgentSpecList = CommandHelp{
 		Command:     "agentspec-list",
 		Description: "List all agent specs with governance info (latest/editing/reviewing/onlineCnt/enable/scope/bizTags/updateTime).",

--- a/internal/prompt/prompt_service.go
+++ b/internal/prompt/prompt_service.go
@@ -42,33 +42,33 @@ type PromptListItem struct {
 
 // PromptVersionSummary represents a version in the governance detail.
 type PromptVersionSummary struct {
-	PromptKey           string `json:"promptKey,omitempty"`
-	Version             string `json:"version"`
-	Status              string `json:"status"`
-	SrcUser             string `json:"srcUser,omitempty"`
+	PromptKey           string  `json:"promptKey,omitempty"`
+	Version             string  `json:"version"`
+	Status              string  `json:"status"`
+	SrcUser             string  `json:"srcUser,omitempty"`
 	CommitMsg           *string `json:"commitMsg,omitempty"`
-	GmtModified         *int64 `json:"gmtModified,omitempty"`
-	PublishPipelineInfo  string `json:"publishPipelineInfo,omitempty"`
-	DownloadCount       *int64 `json:"downloadCount,omitempty"`
+	GmtModified         *int64  `json:"gmtModified,omitempty"`
+	PublishPipelineInfo string  `json:"publishPipelineInfo,omitempty"`
+	DownloadCount       *int64  `json:"downloadCount,omitempty"`
 }
 
 // PromptDetail represents the governance detail (meta + versions).
 type PromptDetail struct {
 	PromptListItem
 	Versions       []string               `json:"versions,omitempty"`
-	VersionDetails []PromptVersionSummary  `json:"versionDetails,omitempty"`
+	VersionDetails []PromptVersionSummary `json:"versionDetails,omitempty"`
 }
 
 // PromptVersionInfo represents a specific prompt version's content.
 type PromptVersionInfo struct {
-	PromptKey   string           `json:"promptKey"`
-	Version     string           `json:"version"`
-	Template    string           `json:"template"`
-	Variables   json.RawMessage  `json:"variables,omitempty"`
-	Status      string           `json:"status,omitempty"`
-	CommitMsg   string           `json:"commitMsg,omitempty"`
-	CreateTime  *int64           `json:"createTime,omitempty"`
-	UpdateTime  *int64           `json:"updateTime,omitempty"`
+	PromptKey  string          `json:"promptKey"`
+	Version    string          `json:"version"`
+	Template   string          `json:"template"`
+	Variables  json.RawMessage `json:"variables,omitempty"`
+	Status     string          `json:"status,omitempty"`
+	CommitMsg  string          `json:"commitMsg,omitempty"`
+	CreateTime *int64          `json:"createTime,omitempty"`
+	UpdateTime *int64          `json:"updateTime,omitempty"`
 }
 
 // ClientPrompt represents the client API response.
@@ -440,5 +440,3 @@ func (s *PromptService) Publish(promptKey, version string, updateLatestLabel boo
 	}
 	return nil
 }
-
-

--- a/internal/prompt/prompt_service.go
+++ b/internal/prompt/prompt_service.go
@@ -1,0 +1,441 @@
+package prompt
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/nacos-group/nacos-cli/internal/client"
+)
+
+// PromptService handles prompt-related operations
+type PromptService struct {
+	client *client.NacosClient
+}
+
+// NewPromptService creates a new prompt service
+func NewPromptService(nacosClient *client.NacosClient) *PromptService {
+	return &PromptService{
+		client: nacosClient,
+	}
+}
+
+// PromptListItem represents a prompt in the admin list.
+type PromptListItem struct {
+	Name             string            `json:"name"`
+	PromptKey        string            `json:"promptKey"`
+	Description      string            `json:"description"`
+	Owner            string            `json:"owner,omitempty"`
+	Enable           bool              `json:"enable"`
+	BizTags          string            `json:"bizTags,omitempty"`
+	Labels           map[string]string `json:"labels,omitempty"`
+	EditingVersion   string            `json:"editingVersion,omitempty"`
+	ReviewingVersion string            `json:"reviewingVersion,omitempty"`
+	OnlineCnt        *int              `json:"onlineCnt,omitempty"`
+	DownloadCount    *int64            `json:"downloadCount,omitempty"`
+	UpdateTime       *int64            `json:"updateTime,omitempty"`
+}
+
+// PromptVersionSummary represents a version in the governance detail.
+type PromptVersionSummary struct {
+	Version             string `json:"version"`
+	Status              string `json:"status"`
+	Author              string `json:"author,omitempty"`
+	CommitMsg           string `json:"commitMsg,omitempty"`
+	CreateTime          *int64 `json:"createTime,omitempty"`
+	UpdateTime          *int64 `json:"updateTime,omitempty"`
+	PublishPipelineInfo  string `json:"publishPipelineInfo,omitempty"`
+	DownloadCount       *int64 `json:"downloadCount,omitempty"`
+}
+
+// PromptDetail represents the governance detail (meta + versions).
+type PromptDetail struct {
+	PromptListItem
+	Versions []PromptVersionSummary `json:"versions,omitempty"`
+}
+
+// PromptVersionInfo represents a specific prompt version's content.
+type PromptVersionInfo struct {
+	PromptKey   string           `json:"promptKey"`
+	Version     string           `json:"version"`
+	Template    string           `json:"template"`
+	Variables   json.RawMessage  `json:"variables,omitempty"`
+	Status      string           `json:"status,omitempty"`
+	CommitMsg   string           `json:"commitMsg,omitempty"`
+	CreateTime  *int64           `json:"createTime,omitempty"`
+	UpdateTime  *int64           `json:"updateTime,omitempty"`
+}
+
+// ClientPrompt represents the client API response.
+type ClientPrompt struct {
+	PromptKey string          `json:"promptKey"`
+	Version   string          `json:"version"`
+	Template  string          `json:"template"`
+	Variables json.RawMessage `json:"variables,omitempty"`
+	Md5       string          `json:"md5,omitempty"`
+}
+
+// PromptListResponse represents the paginated list response.
+type PromptListResponse struct {
+	TotalCount     int              `json:"totalCount"`
+	PageNumber     int              `json:"pageNumber"`
+	PagesAvailable int              `json:"pagesAvailable"`
+	PageItems      []PromptListItem `json:"pageItems"`
+}
+
+// V3Response represents the v3 API response wrapper.
+type V3Response struct {
+	Code    int             `json:"code"`
+	Message string          `json:"message"`
+	Data    json.RawMessage `json:"data"`
+}
+
+// ListPrompts lists prompts with pagination.
+func (s *PromptService) ListPrompts(promptKey string, pageNo, pageSize int) ([]PromptListItem, int, error) {
+	if err := s.client.EnsureTokenValid(); err != nil {
+		return nil, 0, err
+	}
+	params := url.Values{}
+	params.Set("pageNo", fmt.Sprintf("%d", pageNo))
+	params.Set("pageSize", fmt.Sprintf("%d", pageSize))
+	params.Set("namespaceId", s.client.Namespace)
+
+	if promptKey != "" {
+		params.Set("promptKey", promptKey)
+		params.Set("search", "accurate")
+	}
+
+	listURL := fmt.Sprintf("%s/nacos/v3/admin/ai/prompt/list?%s",
+		s.client.BaseURL(), params.Encode())
+
+	req, err := s.client.NewAuthedRequest("GET", listURL, nil)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	httpClient := &http.Client{}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, 0, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body := make([]byte, 1024)
+		n, _ := resp.Body.Read(body)
+		return nil, 0, client.ParseHTTPError(resp.StatusCode, body[:n], "list prompts")
+	}
+
+	var v3Resp V3Response
+	if err := json.NewDecoder(resp.Body).Decode(&v3Resp); err != nil {
+		return nil, 0, fmt.Errorf("decode response: %w", err)
+	}
+	if v3Resp.Code != 0 {
+		return nil, 0, fmt.Errorf("server error: %s", v3Resp.Message)
+	}
+
+	var listResp PromptListResponse
+	if err := json.Unmarshal(v3Resp.Data, &listResp); err != nil {
+		return nil, 0, fmt.Errorf("decode data: %w", err)
+	}
+	return listResp.PageItems, listResp.TotalCount, nil
+}
+
+// DescribePrompt gets the governance detail of a prompt.
+func (s *PromptService) DescribePrompt(promptKey string) (*PromptDetail, error) {
+	if err := s.client.EnsureTokenValid(); err != nil {
+		return nil, err
+	}
+	params := url.Values{}
+	params.Set("namespaceId", s.client.Namespace)
+	params.Set("promptKey", promptKey)
+
+	apiURL := fmt.Sprintf("%s/nacos/v3/admin/ai/prompt/governance?%s",
+		s.client.BaseURL(), params.Encode())
+
+	req, err := s.client.NewAuthedRequest("GET", apiURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	httpClient := &http.Client{}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body := make([]byte, 1024)
+		n, _ := resp.Body.Read(body)
+		return nil, client.ParseHTTPError(resp.StatusCode, body[:n], "describe prompt")
+	}
+
+	var v3Resp V3Response
+	if err := json.NewDecoder(resp.Body).Decode(&v3Resp); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	if v3Resp.Code != 0 {
+		return nil, fmt.Errorf("server error: %s", v3Resp.Message)
+	}
+
+	var detail PromptDetail
+	if err := json.Unmarshal(v3Resp.Data, &detail); err != nil {
+		return nil, fmt.Errorf("decode data: %w", err)
+	}
+	return &detail, nil
+}
+
+// GetPrompt gets a prompt version via client API (version/label/latest).
+func (s *PromptService) GetPrompt(promptKey, version, label string) (*ClientPrompt, error) {
+	if err := s.client.EnsureTokenValid(); err != nil {
+		return nil, err
+	}
+	params := url.Values{}
+	params.Set("namespaceId", s.client.Namespace)
+	params.Set("promptKey", promptKey)
+	if version != "" {
+		params.Set("version", version)
+	}
+	if label != "" {
+		params.Set("label", label)
+	}
+
+	apiURL := fmt.Sprintf("%s/nacos/v3/client/ai/prompt?%s",
+		s.client.BaseURL(), params.Encode())
+
+	req, err := s.client.NewAuthedRequest("GET", apiURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	httpClient := &http.Client{}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body := make([]byte, 1024)
+		n, _ := resp.Body.Read(body)
+		return nil, client.ParseHTTPError(resp.StatusCode, body[:n], "get prompt")
+	}
+
+	var v3Resp V3Response
+	if err := json.NewDecoder(resp.Body).Decode(&v3Resp); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	if v3Resp.Code != 0 {
+		return nil, fmt.Errorf("server error: %s", v3Resp.Message)
+	}
+
+	var prompt ClientPrompt
+	if err := json.Unmarshal(v3Resp.Data, &prompt); err != nil {
+		return nil, fmt.Errorf("decode data: %w", err)
+	}
+	return &prompt, nil
+}
+
+// Draft creates or updates a prompt draft. It first checks if an editing version
+// exists; if so, it updates; otherwise it creates a new draft.
+func (s *PromptService) Draft(promptKey, template, variables, commitMsg, description, bizTags string) error {
+	if err := s.client.EnsureTokenValid(); err != nil {
+		return err
+	}
+
+	// Check if editing version exists
+	hasEditing := false
+	detail, err := s.DescribePrompt(promptKey)
+	if err == nil && detail != nil && detail.EditingVersion != "" {
+		hasEditing = true
+	}
+
+	if hasEditing {
+		return s.updateDraft(promptKey, template, variables, commitMsg)
+	}
+	return s.createDraft(promptKey, template, variables, commitMsg, description, bizTags)
+}
+
+func (s *PromptService) createDraft(promptKey, template, variables, commitMsg, description, bizTags string) error {
+	params := url.Values{}
+	params.Set("namespaceId", s.client.Namespace)
+	params.Set("promptKey", promptKey)
+	params.Set("template", template)
+	if variables != "" {
+		params.Set("variables", variables)
+	}
+	if commitMsg != "" {
+		params.Set("commitMsg", commitMsg)
+	}
+	if description != "" {
+		params.Set("description", description)
+	}
+	if bizTags != "" {
+		params.Set("bizTags", bizTags)
+	}
+
+	apiURL := fmt.Sprintf("%s/nacos/v3/admin/ai/prompt/draft", s.client.BaseURL())
+
+	req, err := s.client.NewAuthedRequest("POST", apiURL, strings.NewReader(params.Encode()))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	httpClient := &http.Client{}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body := make([]byte, 1024)
+		n, _ := resp.Body.Read(body)
+		return client.ParseHTTPError(resp.StatusCode, body[:n], "create draft")
+	}
+
+	var v3Resp V3Response
+	if err := json.NewDecoder(resp.Body).Decode(&v3Resp); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+	if v3Resp.Code != 0 {
+		return fmt.Errorf("server error: %s", v3Resp.Message)
+	}
+	return nil
+}
+
+func (s *PromptService) updateDraft(promptKey, template, variables, commitMsg string) error {
+	params := url.Values{}
+	params.Set("namespaceId", s.client.Namespace)
+	params.Set("promptKey", promptKey)
+	params.Set("template", template)
+	if variables != "" {
+		params.Set("variables", variables)
+	}
+	if commitMsg != "" {
+		params.Set("commitMsg", commitMsg)
+	}
+
+	apiURL := fmt.Sprintf("%s/nacos/v3/admin/ai/prompt/draft", s.client.BaseURL())
+
+	req, err := s.client.NewAuthedRequest("PUT", apiURL, strings.NewReader(params.Encode()))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	httpClient := &http.Client{}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body := make([]byte, 1024)
+		n, _ := resp.Body.Read(body)
+		return client.ParseHTTPError(resp.StatusCode, body[:n], "update draft")
+	}
+
+	var v3Resp V3Response
+	if err := json.NewDecoder(resp.Body).Decode(&v3Resp); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+	if v3Resp.Code != 0 {
+		return fmt.Errorf("server error: %s", v3Resp.Message)
+	}
+	return nil
+}
+
+// Submit submits a prompt draft for review (editing -> reviewing).
+func (s *PromptService) Submit(promptKey, version string) error {
+	if err := s.client.EnsureTokenValid(); err != nil {
+		return err
+	}
+	params := url.Values{}
+	params.Set("namespaceId", s.client.Namespace)
+	params.Set("promptKey", promptKey)
+	if version != "" {
+		params.Set("version", version)
+	}
+
+	apiURL := fmt.Sprintf("%s/nacos/v3/admin/ai/prompt/submit", s.client.BaseURL())
+
+	req, err := s.client.NewAuthedRequest("POST", apiURL, strings.NewReader(params.Encode()))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	httpClient := &http.Client{}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body := make([]byte, 1024)
+		n, _ := resp.Body.Read(body)
+		return client.ParseHTTPError(resp.StatusCode, body[:n], "submit prompt")
+	}
+
+	var v3Resp V3Response
+	if err := json.NewDecoder(resp.Body).Decode(&v3Resp); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+	if v3Resp.Code != 0 {
+		return fmt.Errorf("server error: %s", v3Resp.Message)
+	}
+	return nil
+}
+
+// Publish publishes an approved prompt version (reviewed -> online).
+func (s *PromptService) Publish(promptKey, version string, updateLatestLabel bool) error {
+	if err := s.client.EnsureTokenValid(); err != nil {
+		return err
+	}
+	params := url.Values{}
+	params.Set("namespaceId", s.client.Namespace)
+	params.Set("promptKey", promptKey)
+	params.Set("version", version)
+	if !updateLatestLabel {
+		params.Set("updateLatestLabel", "false")
+	}
+
+	apiURL := fmt.Sprintf("%s/nacos/v3/admin/ai/prompt/publish", s.client.BaseURL())
+
+	req, err := s.client.NewAuthedRequest("POST", apiURL, strings.NewReader(params.Encode()))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	httpClient := &http.Client{}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body := make([]byte, 1024)
+		n, _ := resp.Body.Read(body)
+		return client.ParseHTTPError(resp.StatusCode, body[:n], "publish prompt")
+	}
+
+	var v3Resp V3Response
+	if err := json.NewDecoder(resp.Body).Decode(&v3Resp); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+	if v3Resp.Code != 0 {
+		return fmt.Errorf("server error: %s", v3Resp.Message)
+	}
+	return nil
+}
+
+

--- a/internal/prompt/prompt_service.go
+++ b/internal/prompt/prompt_service.go
@@ -26,26 +26,28 @@ func NewPromptService(nacosClient *client.NacosClient) *PromptService {
 type PromptListItem struct {
 	Name             string            `json:"name"`
 	PromptKey        string            `json:"promptKey"`
-	Description      string            `json:"description"`
+	Description      *string           `json:"description"`
 	Owner            string            `json:"owner,omitempty"`
 	Enable           bool              `json:"enable"`
-	BizTags          string            `json:"bizTags,omitempty"`
+	BizTags          []string          `json:"bizTags,omitempty"`
+	BizTagsStr       *string           `json:"bizTagsStr,omitempty"`
 	Labels           map[string]string `json:"labels,omitempty"`
+	LatestVersion    string            `json:"latestVersion,omitempty"`
 	EditingVersion   string            `json:"editingVersion,omitempty"`
 	ReviewingVersion string            `json:"reviewingVersion,omitempty"`
 	OnlineCnt        *int              `json:"onlineCnt,omitempty"`
 	DownloadCount    *int64            `json:"downloadCount,omitempty"`
-	UpdateTime       *int64            `json:"updateTime,omitempty"`
+	GmtModified      *int64            `json:"gmtModified,omitempty"`
 }
 
 // PromptVersionSummary represents a version in the governance detail.
 type PromptVersionSummary struct {
+	PromptKey           string `json:"promptKey,omitempty"`
 	Version             string `json:"version"`
 	Status              string `json:"status"`
-	Author              string `json:"author,omitempty"`
-	CommitMsg           string `json:"commitMsg,omitempty"`
-	CreateTime          *int64 `json:"createTime,omitempty"`
-	UpdateTime          *int64 `json:"updateTime,omitempty"`
+	SrcUser             string `json:"srcUser,omitempty"`
+	CommitMsg           *string `json:"commitMsg,omitempty"`
+	GmtModified         *int64 `json:"gmtModified,omitempty"`
 	PublishPipelineInfo  string `json:"publishPipelineInfo,omitempty"`
 	DownloadCount       *int64 `json:"downloadCount,omitempty"`
 }
@@ -53,7 +55,8 @@ type PromptVersionSummary struct {
 // PromptDetail represents the governance detail (meta + versions).
 type PromptDetail struct {
 	PromptListItem
-	Versions []PromptVersionSummary `json:"versions,omitempty"`
+	Versions       []string               `json:"versions,omitempty"`
+	VersionDetails []PromptVersionSummary  `json:"versionDetails,omitempty"`
 }
 
 // PromptVersionInfo represents a specific prompt version's content.
@@ -104,7 +107,7 @@ func (s *PromptService) ListPrompts(promptKey string, pageNo, pageSize int) ([]P
 
 	if promptKey != "" {
 		params.Set("promptKey", promptKey)
-		params.Set("search", "accurate")
+		params.Set("search", "blur")
 	}
 
 	listURL := fmt.Sprintf("%s/nacos/v3/admin/ai/prompt/list?%s",

--- a/internal/prompt/prompt_service.go
+++ b/internal/prompt/prompt_service.go
@@ -244,7 +244,7 @@ func (s *PromptService) GetPrompt(promptKey, version, label string) (*ClientProm
 
 // Draft creates or updates a prompt draft. It first checks if an editing version
 // exists; if so, it updates; otherwise it creates a new draft.
-func (s *PromptService) Draft(promptKey, template, variables, commitMsg, description, bizTags string) error {
+func (s *PromptService) Draft(promptKey, template, variables, commitMsg, description, bizTags, targetVersion string) error {
 	if err := s.client.EnsureTokenValid(); err != nil {
 		return err
 	}
@@ -259,10 +259,10 @@ func (s *PromptService) Draft(promptKey, template, variables, commitMsg, descrip
 	if hasEditing {
 		return s.updateDraft(promptKey, template, variables, commitMsg)
 	}
-	return s.createDraft(promptKey, template, variables, commitMsg, description, bizTags)
+	return s.createDraft(promptKey, template, variables, commitMsg, description, bizTags, targetVersion)
 }
 
-func (s *PromptService) createDraft(promptKey, template, variables, commitMsg, description, bizTags string) error {
+func (s *PromptService) createDraft(promptKey, template, variables, commitMsg, description, bizTags, targetVersion string) error {
 	params := url.Values{}
 	params.Set("namespaceId", s.client.Namespace)
 	params.Set("promptKey", promptKey)
@@ -278,6 +278,9 @@ func (s *PromptService) createDraft(promptKey, template, variables, commitMsg, d
 	}
 	if bizTags != "" {
 		params.Set("bizTags", bizTags)
+	}
+	if targetVersion != "" {
+		params.Set("targetVersion", targetVersion)
 	}
 
 	apiURL := fmt.Sprintf("%s/nacos/v3/admin/ai/prompt/draft", s.client.BaseURL())

--- a/internal/prompt/prompt_service.go
+++ b/internal/prompt/prompt_service.go
@@ -244,25 +244,34 @@ func (s *PromptService) GetPrompt(promptKey, version, label string) (*ClientProm
 
 // Draft creates or updates a prompt draft. It first checks if an editing version
 // exists; if so, it updates; otherwise it creates a new draft.
-func (s *PromptService) Draft(promptKey, template, variables, commitMsg, description, bizTags, targetVersion string) error {
+// If basedOnVersion is specified but an editing draft already exists, it returns
+// an error because the server would reject the fork with 409 CONFLICT.
+func (s *PromptService) Draft(promptKey, template, variables, commitMsg, description, bizTags, targetVersion, basedOnVersion string) error {
 	if err := s.client.EnsureTokenValid(); err != nil {
 		return err
 	}
 
 	// Check if editing version exists
 	hasEditing := false
+	editingVer := ""
 	detail, err := s.DescribePrompt(promptKey)
 	if err == nil && detail != nil && detail.EditingVersion != "" {
 		hasEditing = true
+		editingVer = detail.EditingVersion
 	}
 
 	if hasEditing {
+		if basedOnVersion != "" {
+			return fmt.Errorf("cannot fork from version %s: an editing draft (%s) already exists for prompt '%s'. "+
+				"Submit or discard the current draft first, then retry with --based-on-version",
+				basedOnVersion, editingVer, promptKey)
+		}
 		return s.updateDraft(promptKey, template, variables, commitMsg)
 	}
-	return s.createDraft(promptKey, template, variables, commitMsg, description, bizTags, targetVersion)
+	return s.createDraft(promptKey, template, variables, commitMsg, description, bizTags, targetVersion, basedOnVersion)
 }
 
-func (s *PromptService) createDraft(promptKey, template, variables, commitMsg, description, bizTags, targetVersion string) error {
+func (s *PromptService) createDraft(promptKey, template, variables, commitMsg, description, bizTags, targetVersion, basedOnVersion string) error {
 	params := url.Values{}
 	params.Set("namespaceId", s.client.Namespace)
 	params.Set("promptKey", promptKey)
@@ -281,6 +290,9 @@ func (s *PromptService) createDraft(promptKey, template, variables, commitMsg, d
 	}
 	if targetVersion != "" {
 		params.Set("targetVersion", targetVersion)
+	}
+	if basedOnVersion != "" {
+		params.Set("basedOnVersion", basedOnVersion)
 	}
 
 	apiURL := fmt.Sprintf("%s/nacos/v3/admin/ai/prompt/draft", s.client.BaseURL())

--- a/internal/prompt/prompt_service_test.go
+++ b/internal/prompt/prompt_service_test.go
@@ -236,7 +236,7 @@ func TestDraftCreatesNewPrompt(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = NewPromptService(nacosClient).Draft("test-prompt", "Hello!", "", "init", "A test", "", "")
+	err = NewPromptService(nacosClient).Draft("test-prompt", "Hello!", "", "init", "A test", "", "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -280,7 +280,7 @@ func TestDraftUpdatesExistingDraft(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = NewPromptService(nacosClient).Draft("test-prompt", "Updated!", "", "update", "", "", "")
+	err = NewPromptService(nacosClient).Draft("test-prompt", "Updated!", "", "update", "", "", "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -494,7 +494,7 @@ func TestDraftWithVariablesAndBizTags(t *testing.T) {
 	}
 
 	vars := `[{"name":"domain","defaultValue":"coding"}]`
-	err = NewPromptService(nacosClient).Draft("new-prompt", "Hello {{domain}}", vars, "init", "Test desc", "test", "")
+	err = NewPromptService(nacosClient).Draft("new-prompt", "Hello {{domain}}", vars, "init", "Test desc", "test", "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -604,7 +604,7 @@ func TestDraftHTTPErrorHandling(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = NewPromptService(nacosClient).Draft("test-prompt", "Hello!", "", "init", "", "", "")
+	err = NewPromptService(nacosClient).Draft("test-prompt", "Hello!", "", "init", "", "", "", "")
 	if err == nil {
 		t.Fatal("expected error for 409, got nil")
 	}
@@ -647,8 +647,88 @@ func TestDraftWithTargetVersion(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = NewPromptService(nacosClient).Draft("versioned-prompt", "Hello!", "", "init", "", "", "1.0.0")
+	err = NewPromptService(nacosClient).Draft("versioned-prompt", "Hello!", "", "init", "", "", "1.0.0", "")
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestDraftWithBasedOnVersion(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/nacos/v3/admin/ai/prompt/governance":
+			// Prompt exists but no editing version (all versions are online/published)
+			detail := PromptDetail{
+				PromptListItem: PromptListItem{
+					PromptKey:      "fork-prompt",
+					EditingVersion: "", // no editing
+				},
+			}
+			resp := V3Response{Code: 0, Message: "success"}
+			data, _ := json.Marshal(detail)
+			resp.Data = data
+			_ = json.NewEncoder(w).Encode(resp)
+		case "/nacos/v3/admin/ai/prompt/draft":
+			if r.Method != http.MethodPost {
+				t.Fatalf("method = %s, want POST", r.Method)
+			}
+			body, _ := io.ReadAll(r.Body)
+			params := string(body)
+			if !strings.Contains(params, "basedOnVersion=1.0.0") {
+				t.Fatalf("missing basedOnVersion=1.0.0 in body: %s", params)
+			}
+			if !strings.Contains(params, "promptKey=fork-prompt") {
+				t.Fatalf("missing promptKey in body: %s", params)
+			}
+			resp := V3Response{Code: 0, Message: "success"}
+			_ = json.NewEncoder(w).Encode(resp)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	nacosClient, err := newTestNacosClient(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = NewPromptService(nacosClient).Draft("fork-prompt", "Forked!", "", "fork from v1", "", "", "", "1.0.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDraftBasedOnVersionConflictWithEditing(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Prompt exists WITH an editing version
+		detail := PromptDetail{
+			PromptListItem: PromptListItem{
+				PromptKey:      "conflict-prompt",
+				EditingVersion: "0.0.2",
+			},
+		}
+		resp := V3Response{Code: 0, Message: "success"}
+		data, _ := json.Marshal(detail)
+		resp.Data = data
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	nacosClient, err := newTestNacosClient(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Should return error because editing draft exists and basedOnVersion is set
+	err = NewPromptService(nacosClient).Draft("conflict-prompt", "New!", "", "fork", "", "", "", "1.0.0")
+	if err == nil {
+		t.Fatal("expected error when basedOnVersion conflicts with existing editing draft")
+	}
+	if !strings.Contains(err.Error(), "cannot fork") {
+		t.Fatalf("error should mention 'cannot fork': %v", err)
+	}
+	if !strings.Contains(err.Error(), "0.0.2") {
+		t.Fatalf("error should mention editing version '0.0.2': %v", err)
 	}
 }

--- a/internal/prompt/prompt_service_test.go
+++ b/internal/prompt/prompt_service_test.go
@@ -236,7 +236,7 @@ func TestDraftCreatesNewPrompt(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = NewPromptService(nacosClient).Draft("test-prompt", "Hello!", "", "init", "A test", "")
+	err = NewPromptService(nacosClient).Draft("test-prompt", "Hello!", "", "init", "A test", "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -280,7 +280,7 @@ func TestDraftUpdatesExistingDraft(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = NewPromptService(nacosClient).Draft("test-prompt", "Updated!", "", "update", "", "")
+	err = NewPromptService(nacosClient).Draft("test-prompt", "Updated!", "", "update", "", "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -494,7 +494,7 @@ func TestDraftWithVariablesAndBizTags(t *testing.T) {
 	}
 
 	vars := `[{"name":"domain","defaultValue":"coding"}]`
-	err = NewPromptService(nacosClient).Draft("new-prompt", "Hello {{domain}}", vars, "init", "Test desc", "test")
+	err = NewPromptService(nacosClient).Draft("new-prompt", "Hello {{domain}}", vars, "init", "Test desc", "test", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -604,11 +604,51 @@ func TestDraftHTTPErrorHandling(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = NewPromptService(nacosClient).Draft("test-prompt", "Hello!", "", "init", "", "")
+	err = NewPromptService(nacosClient).Draft("test-prompt", "Hello!", "", "init", "", "", "")
 	if err == nil {
 		t.Fatal("expected error for 409, got nil")
 	}
 	if !strings.Contains(err.Error(), "409") && !strings.Contains(err.Error(), "draft already exists") {
 		t.Fatalf("error should mention 409 or conflict: %v", err)
+	}
+}
+
+func TestDraftWithTargetVersion(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/nacos/v3/admin/ai/prompt/governance":
+			// Prompt doesn't exist → triggers create path
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"code": 404, "message": "not found",
+			})
+		case "/nacos/v3/admin/ai/prompt/draft":
+			if r.Method != http.MethodPost {
+				t.Fatalf("method = %s, want POST", r.Method)
+			}
+			body, _ := io.ReadAll(r.Body)
+			params := string(body)
+			if !strings.Contains(params, "targetVersion=1.0.0") {
+				t.Fatalf("missing targetVersion=1.0.0 in body: %s", params)
+			}
+			if !strings.Contains(params, "promptKey=versioned-prompt") {
+				t.Fatalf("missing promptKey in body: %s", params)
+			}
+			resp := V3Response{Code: 0, Message: "success"}
+			_ = json.NewEncoder(w).Encode(resp)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	nacosClient, err := newTestNacosClient(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = NewPromptService(nacosClient).Draft("versioned-prompt", "Hello!", "", "init", "", "", "1.0.0")
+	if err != nil {
+		t.Fatal(err)
 	}
 }

--- a/internal/prompt/prompt_service_test.go
+++ b/internal/prompt/prompt_service_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/nacos-group/nacos-cli/internal/client"
 )
 
+func strPtr(s string) *string { return &s }
+
 func newTestNacosClient(serverURL string) (*client.NacosClient, error) {
 	return client.NewNacosClient(
 		strings.TrimPrefix(serverURL, "http://"),
@@ -54,7 +56,7 @@ func TestListPrompts(t *testing.T) {
 			PageNumber:     1,
 			PagesAvailable: 1,
 			PageItems: []PromptListItem{
-				{PromptKey: "test-prompt", Description: "A test prompt"},
+				{PromptKey: "test-prompt", Description: strPtr("A test prompt")},
 			},
 		}
 		data, _ := json.Marshal(listData)
@@ -88,8 +90,8 @@ func TestListPromptsWithFilter(t *testing.T) {
 		if got := r.URL.Query().Get("promptKey"); got != "my-prompt" {
 			t.Fatalf("promptKey = %s, want my-prompt", got)
 		}
-		if got := r.URL.Query().Get("search"); got != "accurate" {
-			t.Fatalf("search = %s, want accurate", got)
+		if got := r.URL.Query().Get("search"); got != "blur" {
+			t.Fatalf("search = %s, want blur", got)
 		}
 		resp := V3Response{Code: 0, Message: "success"}
 		listData := PromptListResponse{TotalCount: 0, PageItems: []PromptListItem{}}
@@ -125,10 +127,10 @@ func TestDescribePrompt(t *testing.T) {
 		detail := PromptDetail{
 			PromptListItem: PromptListItem{
 				PromptKey:      "test-prompt",
-				Description:    "desc",
+				Description:    strPtr("desc"),
 				EditingVersion: "0.0.1",
 			},
-			Versions: []PromptVersionSummary{
+			VersionDetails: []PromptVersionSummary{
 				{Version: "0.0.1", Status: "draft"},
 			},
 		}
@@ -151,7 +153,7 @@ func TestDescribePrompt(t *testing.T) {
 	if d.EditingVersion != "0.0.1" {
 		t.Fatalf("editingVersion = %s, want 0.0.1", d.EditingVersion)
 	}
-	if len(d.Versions) != 1 || d.Versions[0].Status != "draft" {
+	if len(d.VersionDetails) != 1 || d.VersionDetails[0].Status != "draft" {
 		t.Fatalf("unexpected versions: %+v", d.Versions)
 	}
 }
@@ -383,5 +385,230 @@ func TestPublishPromptNoUpdateLatest(t *testing.T) {
 	err = NewPromptService(nacosClient).Publish("test-prompt", "1.0.0", false)
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestGetPromptWithLabel(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/nacos/v3/client/ai/prompt" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("label"); got != "stable" {
+			t.Fatalf("label = %s, want stable", got)
+		}
+		// version should not be set when label is specified
+		if got := r.URL.Query().Get("version"); got != "" {
+			t.Fatalf("version should be empty, got %s", got)
+		}
+
+		p := ClientPrompt{
+			PromptKey: "test-prompt",
+			Version:   "2.0.0",
+			Template:  "Stable template",
+		}
+		resp := V3Response{Code: 0, Message: "success"}
+		data, _ := json.Marshal(p)
+		resp.Data = data
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	nacosClient, err := newTestNacosClient(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p, err := NewPromptService(nacosClient).GetPrompt("test-prompt", "", "stable")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Version != "2.0.0" {
+		t.Fatalf("version = %s, want 2.0.0", p.Version)
+	}
+	if p.Template != "Stable template" {
+		t.Fatalf("template = %s, want Stable template", p.Template)
+	}
+}
+
+func TestListPromptsEmpty(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := V3Response{Code: 0, Message: "success"}
+		listData := PromptListResponse{TotalCount: 0, PageItems: []PromptListItem{}}
+		data, _ := json.Marshal(listData)
+		resp.Data = data
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	nacosClient, err := newTestNacosClient(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	items, total, err := NewPromptService(nacosClient).ListPrompts("", 1, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 0 {
+		t.Fatalf("totalCount = %d, want 0", total)
+	}
+	if len(items) != 0 {
+		t.Fatalf("expected 0 items, got %d", len(items))
+	}
+}
+
+func TestDraftWithVariablesAndBizTags(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/nacos/v3/admin/ai/prompt/governance":
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"code": 404, "message": "not found",
+			})
+		case "/nacos/v3/admin/ai/prompt/draft":
+			if r.Method != http.MethodPost {
+				t.Fatalf("method = %s, want POST", r.Method)
+			}
+			body, _ := io.ReadAll(r.Body)
+			params := string(body)
+			if !strings.Contains(params, "variables=") {
+				t.Fatalf("missing variables in body: %s", params)
+			}
+			if !strings.Contains(params, "bizTags=test") {
+				t.Fatalf("missing bizTags in body: %s", params)
+			}
+			if !strings.Contains(params, "description=Test+desc") {
+				t.Fatalf("missing description in body: %s", params)
+			}
+			resp := V3Response{Code: 0, Message: "success"}
+			_ = json.NewEncoder(w).Encode(resp)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	nacosClient, err := newTestNacosClient(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vars := `[{"name":"domain","defaultValue":"coding"}]`
+	err = NewPromptService(nacosClient).Draft("new-prompt", "Hello {{domain}}", vars, "init", "Test desc", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSubmitPromptWithVersion(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/nacos/v3/admin/ai/prompt/submit" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		params := string(body)
+		if !strings.Contains(params, "version=0.0.2") {
+			t.Fatalf("missing version=0.0.2 in body: %s", params)
+		}
+		resp := V3Response{Code: 0, Message: "success"}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	nacosClient, err := newTestNacosClient(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = NewPromptService(nacosClient).Submit("test-prompt", "0.0.2")
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDescribePromptNotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"code": 404, "message": "prompt not found",
+		})
+	}))
+	defer server.Close()
+
+	nacosClient, err := newTestNacosClient(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = NewPromptService(nacosClient).DescribePrompt("nonexistent")
+	if err == nil {
+		t.Fatal("expected error for 404, got nil")
+	}
+}
+
+func TestGetPromptVersionPriorityOverLabel(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// When both version and label are provided, version should take priority
+		if got := r.URL.Query().Get("version"); got != "1.0.0" {
+			t.Fatalf("version = %s, want 1.0.0", got)
+		}
+		// label should still be sent (server decides priority)
+		p := ClientPrompt{
+			PromptKey: "test-prompt",
+			Version:   "1.0.0",
+			Template:  "Versioned template",
+		}
+		resp := V3Response{Code: 0, Message: "success"}
+		data, _ := json.Marshal(p)
+		resp.Data = data
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	nacosClient, err := newTestNacosClient(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p, err := NewPromptService(nacosClient).GetPrompt("test-prompt", "1.0.0", "latest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Template != "Versioned template" {
+		t.Fatalf("template = %s, want Versioned template", p.Template)
+	}
+}
+
+func TestDraftHTTPErrorHandling(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/nacos/v3/admin/ai/prompt/governance":
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"code": 404, "message": "not found",
+			})
+		case "/nacos/v3/admin/ai/prompt/draft":
+			// Simulate server error
+			w.WriteHeader(http.StatusConflict)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"code": 409, "message": "draft already exists",
+			})
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	nacosClient, err := newTestNacosClient(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = NewPromptService(nacosClient).Draft("test-prompt", "Hello!", "", "init", "", "")
+	if err == nil {
+		t.Fatal("expected error for 409, got nil")
+	}
+	if !strings.Contains(err.Error(), "409") && !strings.Contains(err.Error(), "draft already exists") {
+		t.Fatalf("error should mention 409 or conflict: %v", err)
 	}
 }

--- a/internal/prompt/prompt_service_test.go
+++ b/internal/prompt/prompt_service_test.go
@@ -1,0 +1,387 @@
+package prompt
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/nacos-group/nacos-cli/internal/client"
+)
+
+func newTestNacosClient(serverURL string) (*client.NacosClient, error) {
+	return client.NewNacosClient(
+		strings.TrimPrefix(serverURL, "http://"),
+		"test-ns",
+		client.AuthTypeNone,
+		"",
+		"",
+		"",
+		"",
+		"",
+		"",
+		"",
+		"http",
+	)
+}
+
+func TestListPrompts(t *testing.T) {
+	var listCalled bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/nacos/v3/admin/ai/prompt/list" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		listCalled = true
+		if r.Method != http.MethodGet {
+			t.Fatalf("method = %s, want GET", r.Method)
+		}
+		if got := r.URL.Query().Get("namespaceId"); got != "test-ns" {
+			t.Fatalf("namespaceId = %s, want test-ns", got)
+		}
+		if got := r.URL.Query().Get("pageNo"); got != "1" {
+			t.Fatalf("pageNo = %s, want 1", got)
+		}
+		if got := r.URL.Query().Get("pageSize"); got != "20" {
+			t.Fatalf("pageSize = %s, want 20", got)
+		}
+
+		resp := V3Response{Code: 0, Message: "success"}
+		listData := PromptListResponse{
+			TotalCount:     1,
+			PageNumber:     1,
+			PagesAvailable: 1,
+			PageItems: []PromptListItem{
+				{PromptKey: "test-prompt", Description: "A test prompt"},
+			},
+		}
+		data, _ := json.Marshal(listData)
+		resp.Data = data
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	nacosClient, err := newTestNacosClient(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	items, total, err := NewPromptService(nacosClient).ListPrompts("", 1, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !listCalled {
+		t.Fatal("list was not called")
+	}
+	if total != 1 {
+		t.Fatalf("totalCount = %d, want 1", total)
+	}
+	if len(items) != 1 || items[0].PromptKey != "test-prompt" {
+		t.Fatalf("unexpected items: %+v", items)
+	}
+}
+
+func TestListPromptsWithFilter(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("promptKey"); got != "my-prompt" {
+			t.Fatalf("promptKey = %s, want my-prompt", got)
+		}
+		if got := r.URL.Query().Get("search"); got != "accurate" {
+			t.Fatalf("search = %s, want accurate", got)
+		}
+		resp := V3Response{Code: 0, Message: "success"}
+		listData := PromptListResponse{TotalCount: 0, PageItems: []PromptListItem{}}
+		data, _ := json.Marshal(listData)
+		resp.Data = data
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	nacosClient, err := newTestNacosClient(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err = NewPromptService(nacosClient).ListPrompts("my-prompt", 1, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDescribePrompt(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/nacos/v3/admin/ai/prompt/governance" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodGet {
+			t.Fatalf("method = %s, want GET", r.Method)
+		}
+		if got := r.URL.Query().Get("promptKey"); got != "test-prompt" {
+			t.Fatalf("promptKey = %s, want test-prompt", got)
+		}
+
+		detail := PromptDetail{
+			PromptListItem: PromptListItem{
+				PromptKey:      "test-prompt",
+				Description:    "desc",
+				EditingVersion: "0.0.1",
+			},
+			Versions: []PromptVersionSummary{
+				{Version: "0.0.1", Status: "draft"},
+			},
+		}
+		resp := V3Response{Code: 0, Message: "success"}
+		data, _ := json.Marshal(detail)
+		resp.Data = data
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	nacosClient, err := newTestNacosClient(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	d, err := NewPromptService(nacosClient).DescribePrompt("test-prompt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.EditingVersion != "0.0.1" {
+		t.Fatalf("editingVersion = %s, want 0.0.1", d.EditingVersion)
+	}
+	if len(d.Versions) != 1 || d.Versions[0].Status != "draft" {
+		t.Fatalf("unexpected versions: %+v", d.Versions)
+	}
+}
+
+func TestGetPrompt(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/nacos/v3/client/ai/prompt" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("promptKey"); got != "test-prompt" {
+			t.Fatalf("promptKey = %s, want test-prompt", got)
+		}
+		if got := r.URL.Query().Get("version"); got != "1.0.0" {
+			t.Fatalf("version = %s, want 1.0.0", got)
+		}
+
+		p := ClientPrompt{
+			PromptKey: "test-prompt",
+			Version:   "1.0.0",
+			Template:  "Hello {{name}}!",
+		}
+		resp := V3Response{Code: 0, Message: "success"}
+		data, _ := json.Marshal(p)
+		resp.Data = data
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	nacosClient, err := newTestNacosClient(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p, err := NewPromptService(nacosClient).GetPrompt("test-prompt", "1.0.0", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Template != "Hello {{name}}!" {
+		t.Fatalf("template = %s, want Hello {{name}}!", p.Template)
+	}
+	if p.Version != "1.0.0" {
+		t.Fatalf("version = %s, want 1.0.0", p.Version)
+	}
+}
+
+func TestDraftCreatesNewPrompt(t *testing.T) {
+	var createCalled bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/nacos/v3/admin/ai/prompt/governance":
+			// Prompt doesn't exist yet -> return error
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"code": 404, "message": "not found",
+			})
+		case "/nacos/v3/admin/ai/prompt/draft":
+			if r.Method != http.MethodPost {
+				t.Fatalf("draft method = %s, want POST", r.Method)
+			}
+			createCalled = true
+			body, _ := io.ReadAll(r.Body)
+			params := string(body)
+			if !strings.Contains(params, "promptKey=test-prompt") {
+				t.Fatalf("missing promptKey in body: %s", params)
+			}
+			if !strings.Contains(params, "template=") {
+				t.Fatalf("missing template in body: %s", params)
+			}
+			resp := V3Response{Code: 0, Message: "success"}
+			_ = json.NewEncoder(w).Encode(resp)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	nacosClient, err := newTestNacosClient(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = NewPromptService(nacosClient).Draft("test-prompt", "Hello!", "", "init", "A test", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !createCalled {
+		t.Fatal("createDraft was not called")
+	}
+}
+
+func TestDraftUpdatesExistingDraft(t *testing.T) {
+	var updateCalled bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/nacos/v3/admin/ai/prompt/governance":
+			// Prompt exists with editing version
+			detail := PromptDetail{
+				PromptListItem: PromptListItem{
+					PromptKey:      "test-prompt",
+					EditingVersion: "0.0.1",
+				},
+			}
+			resp := V3Response{Code: 0, Message: "success"}
+			data, _ := json.Marshal(detail)
+			resp.Data = data
+			_ = json.NewEncoder(w).Encode(resp)
+		case "/nacos/v3/admin/ai/prompt/draft":
+			if r.Method != http.MethodPut {
+				t.Fatalf("draft method = %s, want PUT", r.Method)
+			}
+			updateCalled = true
+			resp := V3Response{Code: 0, Message: "success"}
+			_ = json.NewEncoder(w).Encode(resp)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	nacosClient, err := newTestNacosClient(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = NewPromptService(nacosClient).Draft("test-prompt", "Updated!", "", "update", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !updateCalled {
+		t.Fatal("updateDraft was not called")
+	}
+}
+
+func TestSubmitPrompt(t *testing.T) {
+	var submitCalled bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/nacos/v3/admin/ai/prompt/submit" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		submitCalled = true
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		body, _ := io.ReadAll(r.Body)
+		params := string(body)
+		if !strings.Contains(params, "promptKey=test-prompt") {
+			t.Fatalf("missing promptKey: %s", params)
+		}
+		if !strings.Contains(params, "namespaceId=test-ns") {
+			t.Fatalf("missing namespaceId: %s", params)
+		}
+		resp := V3Response{Code: 0, Message: "success"}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	nacosClient, err := newTestNacosClient(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = NewPromptService(nacosClient).Submit("test-prompt", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !submitCalled {
+		t.Fatal("submit was not called")
+	}
+}
+
+func TestPublishPrompt(t *testing.T) {
+	var publishCalled bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/nacos/v3/admin/ai/prompt/publish" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		publishCalled = true
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		body, _ := io.ReadAll(r.Body)
+		params := string(body)
+		if !strings.Contains(params, "promptKey=test-prompt") {
+			t.Fatalf("missing promptKey: %s", params)
+		}
+		if !strings.Contains(params, "version=1.0.0") {
+			t.Fatalf("missing version: %s", params)
+		}
+		resp := V3Response{Code: 0, Message: "success"}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	nacosClient, err := newTestNacosClient(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = NewPromptService(nacosClient).Publish("test-prompt", "1.0.0", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !publishCalled {
+		t.Fatal("publish was not called")
+	}
+}
+
+func TestPublishPromptNoUpdateLatest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		params := string(body)
+		if !strings.Contains(params, "updateLatestLabel=false") {
+			t.Fatalf("expected updateLatestLabel=false in body: %s", params)
+		}
+		resp := V3Response{Code: 0, Message: "success"}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	nacosClient, err := newTestNacosClient(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = NewPromptService(nacosClient).Publish("test-prompt", "1.0.0", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary

Add prompt management commands for Nacos AI prompt templates.

Closes #68

- `prompt-list` — List prompts with fuzzy search (`--name`) and pagination
- `prompt-describe` — Show prompt detail, governance state, and version table
- `prompt-get` — Download prompt template to stdout or file (by version/label)
- `prompt-draft` — Create or update a draft (auto-detects via governance API)
- `prompt-review` — Submit draft for review
- `prompt-release` — Publish approved version online

## Design

- Prompts follow the same lifecycle as skills: `draft → review → release`
- `prompt-draft` auto-detects create vs update by querying governance endpoint:
  - If `editingVersion` exists → PUT `/v3/admin/ai/prompt/draft`
  - Otherwise (including 404) → POST `/v3/admin/ai/prompt/draft`
- All URLs constructed via `client.BaseURL()` for HTTPS compatibility (PR #61)
- Supports `--target-version` for explicit version control on draft creation

## Test Plan

- [x] 16 unit tests covering all API methods + edge cases (PASS)
- [x] Full lifecycle E2E test against local Nacos server:
  `prompt-list` → `prompt-draft` (create) → `prompt-describe` → `prompt-review` → `prompt-release` → `prompt-get` → `prompt-draft` (update)
- [x] CI: Lint + Test + Build (6 platforms) all green

## Files Changed (5 new + 3 modified)

**New:**
- `internal/prompt/prompt_service.go` — Service layer
- `internal/prompt/prompt_service_test.go` — 16 unit tests
- `cmd/list_prompt.go` / `cmd/describe_prompt.go` / `cmd/get_prompt.go` / `cmd/draft_prompt.go` / `cmd/review_prompt.go` / `cmd/release_prompt.go`

**Modified:**
- `internal/help/help.go` — Help text definitions
- `README.md` — Feature docs + changelog