### PR TITLE
fix: send cluster id for sts hiclaw credentials

### DIFF
--- a/internal/client/nacos_client.go
+++ b/internal/client/nacos_client.go
@@ -348,9 +348,12 @@ func (c *NacosClient) doWithStsRetry(build func() (*resty.Response, error)) (*re
 // fetchStsCredentials calls the STS URL to obtain temporary AK/SK/SecurityToken
 func (c *NacosClient) fetchStsCredentials() error {
 	fmt.Fprintf(os.Stderr, "[info] sts-hiclaw: fetching STS credentials from %s\n", c.StsURL)
-	resp, err := c.httpClient.R().
-		SetHeader("Authorization", "Bearer "+c.StsAuthToken).
-		Post(c.StsURL)
+	req := c.httpClient.R().
+		SetHeader("Authorization", "Bearer "+c.StsAuthToken)
+	if clusterID := os.Getenv("HICLAW_CLUSTER_ID"); clusterID != "" {
+		req.SetHeader("X-HiClaw-Cluster-ID", clusterID)
+	}
+	resp, err := req.Post(c.StsURL)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "[warn] sts-hiclaw: STS request failed: %v\n", err)
 		return fmt.Errorf("request STS URL failed: %w", err)

--- a/internal/client/nacos_client_test.go
+++ b/internal/client/nacos_client_test.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 )
 
@@ -94,5 +96,38 @@ func TestNewNacosClientDefaultScheme(t *testing.T) {
 	}
 	if c.BaseURL() != "http://localhost:8848" {
 		t.Errorf("BaseURL() = %q, want %q", c.BaseURL(), "http://localhost:8848")
+	}
+}
+
+func TestFetchStsCredentialsSendsClusterIDHeader(t *testing.T) {
+	t.Setenv("HICLAW_CLUSTER_ID", "cluster-123")
+
+	stsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer auth-token" {
+			t.Fatalf("Authorization header = %q, want %q", got, "Bearer auth-token")
+		}
+		if got := r.Header.Get("X-HiClaw-Cluster-ID"); got != "cluster-123" {
+			t.Fatalf("X-HiClaw-Cluster-ID header = %q, want %q", got, "cluster-123")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_key_id":"ak","access_key_secret":"sk","security_token":"token","expires_in_sec":600}`))
+	}))
+	defer stsServer.Close()
+
+	c, err := NewNacosClient(
+		"localhost:8848",
+		"public",
+		AuthTypeStsToken,
+		"", "", "", "", "",
+		stsServer.URL,
+		"auth-token",
+		"",
+	)
+	if err != nil {
+		t.Fatalf("NewNacosClient() error = %v", err)
+	}
+	if c.AccessKey != "ak" || c.SecretKey != "sk" || c.SecurityToken != "token" {
+		t.Fatalf("STS credentials = (%q, %q, %q), want (ak, sk, token)", c.AccessKey, c.SecretKey, c.SecurityToken)
 	}
 }


### PR DESCRIPTION
## Summary

- Add `X-HiClaw-Cluster-ID` to the sts-hiclaw credential request when `HICLAW_CLUSTER_ID` is set.
- Keep the existing STS credential flow unchanged otherwise.
- Add a unit test to verify the controller request includes both the bearer token and cluster ID header.

## Testing

- `/opt/homebrew/bin/go test ./...`