### PR TITLE
fix: publish prerelease npm versions with dist tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,4 +79,12 @@ jobs:
           done
 
       - name: Publish to npm
-        run: npm publish --access public --provenance
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          if [[ "$VERSION" == *-* ]]; then
+            DIST_TAG="${VERSION#*-}"
+            DIST_TAG="${DIST_TAG%%.*}"
+            npm publish --access public --provenance --tag "$DIST_TAG"
+          else
+            npm publish --access public --provenance
+          fi


### PR DESCRIPTION
## Summary

- Keep stable npm releases publishing with the default dist-tag.
- Publish prerelease versions with a dist-tag derived from the prerelease identifier, e.g. `1.0.5-beta.2` uses `--tag beta`.
- Prevent beta/rc npm releases from unintentionally updating `latest`.

## Testing

- Verified shell logic locally for `1.0.5`, `1.0.5-beta.2`, and `1.0.5-rc.1`.
- `git diff --check`