### PR TITLE
fix: use supported npm trusted publishing runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,8 +42,9 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
 
       - name: Extract version from tag
         id: version
@@ -84,7 +85,7 @@ jobs:
           if [[ "$VERSION" == *-* ]]; then
             DIST_TAG="${VERSION#*-}"
             DIST_TAG="${DIST_TAG%%.*}"
-            npm publish --access public --provenance --tag "$DIST_TAG"
+            npm publish --access public --tag "$DIST_TAG"
           else
-            npm publish --access public --provenance
+            npm publish --access public
           fi


### PR DESCRIPTION
## Summary

- Use Node 24 for the npm publish job so the bundled npm CLI satisfies npm trusted publishing requirements.
- Disable package-manager cache in the release publish job.
- Remove explicit `--provenance`; trusted publishing generates provenance automatically.
- Keep prerelease dist-tag behavior, e.g. `1.0.5-beta.2` publishes with `--tag beta`.

## Why

The `v1.0.5-beta.2` release run succeeded in GoReleaser but failed during npm publish. The log showed npm 10.8.2 from Node 20 and then a registry 404 while publishing `@nacos-group/cli@1.0.5-beta.2` with tag `beta`. npm trusted publishing currently requires npm CLI 11.5.1+ and Node 22.14+.

## Testing

- Verified shell dist-tag logic locally for `1.0.5`, `1.0.5-beta.2`, and `1.0.5-rc.1`.
- `git diff --check`