### PR TITLE
feat: support skill upload overwrite flag

### DIFF
--- a/cmd/publish_skill.go
+++ b/cmd/publish_skill.go
@@ -70,7 +70,7 @@ func publishSingleLegacy(skillPath string, skillService *skill.SkillService) {
 
 	skillName := deriveSkillNameFromPath(absPath)
 	fmt.Printf("[1/2] Uploading skill: %s...\n", skillName)
-	if err := skillService.UploadSkill(absPath); err != nil {
+	if err := skillService.UploadSkill(absPath, false); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: upload failed for '%s': %v\n", skillName, err)
 		os.Exit(1)
 	}
@@ -127,7 +127,7 @@ func publishAllLegacy(folderPath string, skillService *skill.SkillService) {
 		fmt.Println(strings.Repeat("=", 80))
 
 		skillPath := filepath.Join(folderPath, skillName)
-		if err := skillService.UploadSkill(skillPath); err != nil {
+		if err := skillService.UploadSkill(skillPath, false); err != nil {
 			fmt.Printf("Upload failed: %v\n", err)
 			failedCount++
 			fmt.Println()

--- a/cmd/upload_skill.go
+++ b/cmd/upload_skill.go
@@ -12,6 +12,7 @@ import (
 )
 
 var uploadAll bool
+var uploadOverwrite bool
 
 var uploadSkillCmd = &cobra.Command{
 	Use:   "skill-upload [skillPath]",
@@ -29,14 +30,42 @@ var uploadSkillCmd = &cobra.Command{
 		skillService := skill.NewSkillService(nacosClient)
 
 		if uploadAll {
-			uploadAllSkills(skillPath, skillService)
+			uploadAllSkills(skillPath, skillService, uploadOverwrite)
 			return
 		}
-		uploadSingleSkill(skillPath, skillService)
+		uploadSingleSkill(skillPath, skillService, uploadOverwrite)
 	},
 }
 
-func uploadSingleSkill(skillPath string, skillService *skill.SkillService) {
+type overwriteFlagValue struct {
+	value *bool
+}
+
+func (flag overwriteFlagValue) Set(value string) error {
+	switch value {
+	case "false":
+		*flag.value = false
+		return nil
+	case "true":
+		*flag.value = true
+		return nil
+	default:
+		return fmt.Errorf("--overwrite must be true or false")
+	}
+}
+
+func (flag overwriteFlagValue) String() string {
+	if flag.value == nil {
+		return "false"
+	}
+	return fmt.Sprintf("%t", *flag.value)
+}
+
+func (flag overwriteFlagValue) Type() string {
+	return "bool"
+}
+
+func uploadSingleSkill(skillPath string, skillService *skill.SkillService, overwrite bool) {
 	if strings.HasPrefix(skillPath, "~") {
 		homeDir, err := os.UserHomeDir()
 		checkError(err)
@@ -49,14 +78,14 @@ func uploadSingleSkill(skillPath string, skillService *skill.SkillService) {
 	skillName := filepath.Base(absPath)
 	fmt.Printf("Uploading skill: %s...\n", skillName)
 
-	err = skillService.UploadSkill(absPath)
+	err = skillService.UploadSkill(absPath, overwrite)
 	checkError(err)
 
 	fmt.Printf("Skill draft uploaded successfully!\n")
 	fmt.Printf("  Tip: Use 'skill-review %s' to submit the draft for review.\n", skillName)
 }
 
-func uploadAllSkills(folderPath string, skillService *skill.SkillService) {
+func uploadAllSkills(folderPath string, skillService *skill.SkillService, overwrite bool) {
 	if strings.HasPrefix(folderPath, "~") {
 		homeDir, err := os.UserHomeDir()
 		checkError(err)
@@ -97,7 +126,7 @@ func uploadAllSkills(folderPath string, skillService *skill.SkillService) {
 		fmt.Println(strings.Repeat("=", 80))
 
 		skillPath := filepath.Join(folderPath, skillName)
-		if err := skillService.UploadSkill(skillPath); err != nil {
+		if err := skillService.UploadSkill(skillPath, overwrite); err != nil {
 			fmt.Printf("Upload failed: %v\n", err)
 			failedCount++
 		} else {
@@ -121,5 +150,6 @@ func uploadAllSkills(folderPath string, skillService *skill.SkillService) {
 
 func init() {
 	uploadSkillCmd.Flags().BoolVar(&uploadAll, "all", false, "Upload all skills in the directory")
+	uploadSkillCmd.Flags().Var(overwriteFlagValue{value: &uploadOverwrite}, "overwrite", "Whether to overwrite existing draft: true | false")
 	rootCmd.AddCommand(uploadSkillCmd)
 }

--- a/cmd/upload_skill_test.go
+++ b/cmd/upload_skill_test.go
@@ -1,0 +1,37 @@
+package cmd
+
+import "testing"
+
+func TestOverwriteFlagValue(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     string
+		want      bool
+		wantError bool
+	}{
+		{name: "true", value: "true", want: true},
+		{name: "false", value: "false", want: false},
+		{name: "uppercase rejected", value: "TRUE", wantError: true},
+		{name: "numeric rejected", value: "1", wantError: true},
+		{name: "empty rejected", value: "", wantError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := false
+			err := overwriteFlagValue{value: &got}.Set(tt.value)
+			if tt.wantError {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("value = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/help/help.go
+++ b/internal/help/help.go
@@ -76,10 +76,14 @@ var (
 		Parameters: []string{
 			"skillPath       Required. Path to the skill directory (or .zip file)",
 			"--all           Upload all skills in the specified directory",
+			"--overwrite     Whether to overwrite an existing draft: true | false (default: false)",
 		},
 		Examples: []string{
 			"# Upload a single skill",
 			"skill-upload ./my-skill",
+			"",
+			"# Upload and overwrite an existing draft",
+			"skill-upload ./my-skill --overwrite true",
 			"",
 			"# Upload all skills in a directory",
 			"skill-upload --all ./skills-folder",

--- a/internal/skill/skill_service.go
+++ b/internal/skill/skill_service.go
@@ -386,10 +386,10 @@ func extractZip(zipBytes []byte, targetDir string) error {
 	return nil
 }
 
-// UploadSkill uploads a skill from local directory or a pre-built zip file.
+// UploadSkill uploads a skill draft from local directory or a pre-built zip file.
 // If skillPath points to a .zip file it is uploaded directly; otherwise the
 // directory is packed into a zip on-the-fly (skillName/... structure).
-func (s *SkillService) UploadSkill(skillPath string) error {
+func (s *SkillService) UploadSkill(skillPath string, overwrite bool) error {
 	if err := s.client.EnsureTokenValid(); err != nil {
 		return err
 	}
@@ -465,8 +465,8 @@ func (s *SkillService) UploadSkill(skillPath string) error {
 	}
 
 	// Send HTTP request
-	uploadURL := fmt.Sprintf("%s/nacos/v3/admin/ai/skills/upload?namespaceId=%s",
-		s.client.BaseURL(), s.client.Namespace)
+	uploadURL := fmt.Sprintf("%s/nacos/v3/admin/ai/skills/upload?namespaceId=%s&overwrite=%t",
+		s.client.BaseURL(), s.client.Namespace, overwrite)
 	req, err := s.client.NewAuthedRequest("POST", uploadURL, body)
 	if err != nil {
 		return err

--- a/internal/skill/skill_service_test.go
+++ b/internal/skill/skill_service_test.go
@@ -28,6 +28,9 @@ func TestUploadSkillOnlyUploadsDraft(t *testing.T) {
 			if got := r.URL.Query().Get("namespaceId"); got != "test-ns" {
 				t.Fatalf("upload namespaceId = %s, want test-ns", got)
 			}
+			if got := r.URL.Query().Get("overwrite"); got != "false" {
+				t.Fatalf("upload overwrite = %s, want false", got)
+			}
 			if err := r.ParseMultipartForm(1 << 20); err != nil {
 				t.Fatalf("parse multipart upload: %v", err)
 			}
@@ -68,11 +71,44 @@ func TestUploadSkillOnlyUploadsDraft(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := NewSkillService(nacosClient).UploadSkill(skillDir); err != nil {
+	if err := NewSkillService(nacosClient).UploadSkill(skillDir, false); err != nil {
 		t.Fatal(err)
 	}
 	if !uploadCalled {
 		t.Fatal("upload was not called")
+	}
+}
+
+func TestUploadSkillSendsOverwriteQueryParam(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/nacos/v3/admin/ai/skills/upload" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("namespaceId"); got != "test-ns" {
+			t.Fatalf("upload namespaceId = %s, want test-ns", got)
+		}
+		if got := r.URL.Query().Get("overwrite"); got != "true" {
+			t.Fatalf("upload overwrite = %s, want true", got)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	skillDir := t.TempDir() + "/demo-skill"
+	if err := os.Mkdir(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(skillDir+"/SKILL.md", []byte("# Demo Skill\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	nacosClient, err := newTestNacosClient(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := NewSkillService(nacosClient).UploadSkill(skillDir, true); err != nil {
+		t.Fatal(err)
 	}
 }
 
@@ -247,7 +283,7 @@ func TestUploadSkillZipPaths(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := NewSkillService(nacosClient).UploadSkill(skillDir); err != nil {
+	if err := NewSkillService(nacosClient).UploadSkill(skillDir, false); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -84,6 +84,7 @@ func completer() *readline.PrefixCompleter {
 			readline.PcItem("--help"),
 			readline.PcItem("-h"),
 			readline.PcItem("--all"),
+			readline.PcItem("--overwrite"),
 		),
 		readline.PcItem("skill-publish",
 			readline.PcItem("--help"),
@@ -896,7 +897,17 @@ func (t *Terminal) getSkill(args []string) {
 // uploadSkill uploads a skill draft (editing state)
 func (t *Terminal) uploadSkill(args []string) {
 	if len(args) == 0 {
-		fmt.Println("Usage: skill-upload <skillPath> or skill-upload --all <folder>")
+		fmt.Println("Usage: skill-upload <skillPath> [--overwrite true|false] or skill-upload --all <folder> [--overwrite true|false]")
+		return
+	}
+
+	args, overwrite, err := parseSkillUploadOverwrite(args)
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		return
+	}
+	if len(args) == 0 {
+		fmt.Println("Usage: skill-upload <skillPath> [--overwrite true|false] or skill-upload --all <folder> [--overwrite true|false]")
 		return
 	}
 
@@ -924,10 +935,10 @@ func (t *Terminal) uploadSkill(args []string) {
 	if allFlagIndex >= 0 {
 		if folderPath == "" {
 			fmt.Println("Error: folder path required for --all flag")
-			fmt.Println("Usage: skill-upload --all <folder> or skill-upload <folder> --all")
+			fmt.Println("Usage: skill-upload --all <folder> [--overwrite true|false] or skill-upload <folder> --all [--overwrite true|false]")
 			return
 		}
-		t.uploadAllSkills(folderPath)
+		t.uploadAllSkills(folderPath, overwrite)
 		return
 	}
 
@@ -953,7 +964,7 @@ func (t *Terminal) uploadSkill(args []string) {
 
 	fmt.Printf("Uploading skill: %s...\n", skillPath)
 
-	err := t.skillService.UploadSkill(skillPath)
+	err = t.skillService.UploadSkill(skillPath, overwrite)
 	if err != nil {
 		fmt.Printf("Error: %v\n", err)
 		return
@@ -963,8 +974,39 @@ func (t *Terminal) uploadSkill(args []string) {
 	fmt.Printf("Tip: Use 'skill-review %s' to submit the draft for review.\n", filepath.Base(skillPath))
 }
 
+func parseSkillUploadOverwrite(args []string) ([]string, bool, error) {
+	overwrite := false
+	filtered := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		value := ""
+		if arg == "--overwrite" {
+			if i+1 >= len(args) {
+				return nil, false, fmt.Errorf("--overwrite must be true or false")
+			}
+			i++
+			value = args[i]
+		} else if strings.HasPrefix(arg, "--overwrite=") {
+			value = strings.TrimPrefix(arg, "--overwrite=")
+		} else {
+			filtered = append(filtered, arg)
+			continue
+		}
+
+		switch value {
+		case "false":
+			overwrite = false
+		case "true":
+			overwrite = true
+		default:
+			return nil, false, fmt.Errorf("--overwrite must be true or false")
+		}
+	}
+	return filtered, overwrite, nil
+}
+
 // uploadAllSkills publishes all skill drafts in a directory
-func (t *Terminal) uploadAllSkills(folderPath string) {
+func (t *Terminal) uploadAllSkills(folderPath string, overwrite bool) {
 	// Expand ~ to home directory
 	if strings.HasPrefix(folderPath, "~/") {
 		homeDir, err := os.UserHomeDir()
@@ -1022,7 +1064,7 @@ func (t *Terminal) uploadAllSkills(folderPath string) {
 		fmt.Println(strings.Repeat("=", 80))
 
 		skillPath := filepath.Join(folderPath, skillName)
-		err := t.skillService.UploadSkill(skillPath)
+		err := t.skillService.UploadSkill(skillPath, overwrite)
 		if err != nil {
 			fmt.Printf("Publish failed: %v\n", err)
 			failedCount++
@@ -1211,7 +1253,7 @@ func (t *Terminal) publishLegacy(args []string) {
 			return
 		}
 		// Upload all first, then submit all drafts for review.
-		t.uploadAllSkills(folderPath)
+		t.uploadAllSkills(folderPath, false)
 		t.reviewAllSkills(folderPath)
 		return
 	}
@@ -1234,7 +1276,7 @@ func (t *Terminal) publishLegacy(args []string) {
 	}
 
 	fmt.Printf("[1/2] Uploading skill: %s...\n", skillPath)
-	if err := t.skillService.UploadSkill(skillPath); err != nil {
+	if err := t.skillService.UploadSkill(skillPath, false); err != nil {
 		fmt.Printf("Error: %v\n", err)
 		return
 	}

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -96,6 +96,13 @@ func TestParseCommandArgs(t *testing.T) {
 			expectedArgs: []string{"-h"},
 			description:  "Short help flag should be recognized as boolean",
 		},
+		{
+			name:         "skill upload overwrite flag with value",
+			input:        "skill-upload ./my-skill --overwrite true",
+			expectedCmd:  "skill-upload",
+			expectedArgs: []string{"./my-skill", "--overwrite", "true"},
+			description:  "Overwrite flag should consume true or false as its value",
+		},
 	}
 
 	for _, tt := range tests {
@@ -116,6 +123,71 @@ func TestParseCommandArgs(t *testing.T) {
 				if i < len(tt.expectedArgs) && arg != tt.expectedArgs[i] {
 					t.Errorf("parseCommandArgs(%q) args[%d] = %q, want %q\nFull got:  %v\nFull want: %v\nTest: %s\nDescription: %s",
 						tt.input, i, arg, tt.expectedArgs[i], args, tt.expectedArgs, tt.name, tt.description)
+				}
+			}
+		})
+	}
+}
+
+func TestParseSkillUploadOverwrite(t *testing.T) {
+	tests := []struct {
+		name           string
+		args           []string
+		expectedArgs   []string
+		expectedResult bool
+		wantErr        bool
+	}{
+		{
+			name:           "default false",
+			args:           []string{"./my-skill"},
+			expectedArgs:   []string{"./my-skill"},
+			expectedResult: false,
+		},
+		{
+			name:           "separate true value",
+			args:           []string{"./my-skill", "--overwrite", "true"},
+			expectedArgs:   []string{"./my-skill"},
+			expectedResult: true,
+		},
+		{
+			name:           "equals false value",
+			args:           []string{"--overwrite=false", "./my-skill"},
+			expectedArgs:   []string{"./my-skill"},
+			expectedResult: false,
+		},
+		{
+			name:    "missing value",
+			args:    []string{"./my-skill", "--overwrite"},
+			wantErr: true,
+		},
+		{
+			name:    "invalid value",
+			args:    []string{"./my-skill", "--overwrite", "yes"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args, overwrite, err := parseSkillUploadOverwrite(tt.args)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if overwrite != tt.expectedResult {
+				t.Fatalf("overwrite = %v, want %v", overwrite, tt.expectedResult)
+			}
+			if len(args) != len(tt.expectedArgs) {
+				t.Fatalf("args length = %d, want %d; got %v", len(args), len(tt.expectedArgs), args)
+			}
+			for i, arg := range args {
+				if arg != tt.expectedArgs[i] {
+					t.Fatalf("args[%d] = %q, want %q", i, arg, tt.expectedArgs[i])
 				}
 			}
 		})


### PR DESCRIPTION
## 变更内容

- 为 `skill-upload` 增加 `--overwrite true|false` 参数
- 上传 skill 时在请求 URL 中追加 `overwrite=true|false`
- 交互模式下的 `skill-upload` 也支持 overwrite 参数，包括批量上传
- 保持废弃命令 `skill-publish` 的兼容行为，默认使用 `overwrite=false`
- 增加 overwrite 参数解析和上传 query 参数相关测试