### PR TITLE
fix: replace skill directory on skill-get

### DIFF
--- a/internal/skill/skill_service.go
+++ b/internal/skill/skill_service.go
@@ -10,8 +10,10 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/nacos-group/nacos-cli/internal/client"
 	"gopkg.in/yaml.v3"
@@ -335,8 +337,7 @@ func (s *SkillService) GetSkill(skillName, outputDir string, version, label stri
 		return client.ParseHTTPError(resp.StatusCode, zipBytes, "get skill")
 	}
 
-	// Extract ZIP to output directory
-	return extractZip(zipBytes, outputDir)
+	return replaceSkillFromZip(zipBytes, outputDir, skillName)
 }
 
 // ExtractSkillZip extracts a ZIP byte array to the target directory.
@@ -348,12 +349,12 @@ func ExtractSkillZip(zipBytes []byte, targetDir string) error {
 	}
 
 	for _, f := range zipReader.File {
-		// Security: reject path traversal
-		if strings.Contains(f.Name, "..") {
-			return fmt.Errorf("unsafe zip entry path: %s", f.Name)
+		zipPath, err := normalizeZipEntryPath(f.Name)
+		if err != nil {
+			return err
 		}
 
-		destPath := filepath.Join(targetDir, f.Name)
+		destPath := filepath.Join(targetDir, filepath.FromSlash(zipPath))
 
 		if f.FileInfo().IsDir() {
 			if err := os.MkdirAll(destPath, 0755); err != nil {
@@ -383,6 +384,101 @@ func ExtractSkillZip(zipBytes []byte, targetDir string) error {
 		}
 	}
 
+	return nil
+}
+
+func normalizeZipEntryPath(name string) (string, error) {
+	normalized := path.Clean(strings.ReplaceAll(name, "\\", "/"))
+	if normalized == "." || normalized == "" {
+		return "", fmt.Errorf("unsafe zip entry path: %s", name)
+	}
+	if strings.HasPrefix(normalized, "/") || normalized == ".." || strings.HasPrefix(normalized, "../") {
+		return "", fmt.Errorf("unsafe zip entry path: %s", name)
+	}
+	return normalized, nil
+}
+
+func validateSkillZip(zipBytes []byte, skillName string) error {
+	zipReader, err := zip.NewReader(bytes.NewReader(zipBytes), int64(len(zipBytes)))
+	if err != nil {
+		return fmt.Errorf("failed to read zip: %w", err)
+	}
+
+	hasSkillRoot := false
+	hasSkillMD := false
+	expectedPrefix := skillName + "/"
+
+	for _, f := range zipReader.File {
+		zipPath, err := normalizeZipEntryPath(f.Name)
+		if err != nil {
+			return err
+		}
+		if zipPath != skillName && !strings.HasPrefix(zipPath, expectedPrefix) {
+			return fmt.Errorf("unexpected zip entry path %q: expected all files under %s/", f.Name, skillName)
+		}
+		hasSkillRoot = true
+		if zipPath == expectedPrefix+"SKILL.md" {
+			hasSkillMD = true
+		}
+	}
+
+	if !hasSkillRoot {
+		return fmt.Errorf("zip does not contain skill directory %s/", skillName)
+	}
+	if !hasSkillMD {
+		return fmt.Errorf("zip does not contain %s/SKILL.md", skillName)
+	}
+	return nil
+}
+
+func replaceSkillFromZip(zipBytes []byte, outputDir, skillName string) error {
+	if err := validateSkillZip(zipBytes, skillName); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		return fmt.Errorf("failed to create output directory: %w", err)
+	}
+
+	stageRoot, err := os.MkdirTemp(outputDir, ".skill-stage-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temp directory: %w", err)
+	}
+	defer os.RemoveAll(stageRoot)
+
+	if err := ExtractSkillZip(zipBytes, stageRoot); err != nil {
+		return err
+	}
+
+	stagedSkillDir := filepath.Join(stageRoot, skillName)
+	if _, err := os.Stat(filepath.Join(stagedSkillDir, "SKILL.md")); err != nil {
+		return fmt.Errorf("invalid skill zip: missing %s/SKILL.md", skillName)
+	}
+
+	targetSkillDir := filepath.Join(outputDir, skillName)
+	backupSkillDir := filepath.Join(outputDir, fmt.Sprintf(".%s.backup-%d", skillName, time.Now().UnixNano()))
+	backupCreated := false
+
+	if _, err := os.Stat(targetSkillDir); err == nil {
+		if err := os.Rename(targetSkillDir, backupSkillDir); err != nil {
+			return fmt.Errorf("failed to backup existing skill: %w", err)
+		}
+		backupCreated = true
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("failed to inspect existing skill: %w", err)
+	}
+
+	if err := os.Rename(stagedSkillDir, targetSkillDir); err != nil {
+		if backupCreated {
+			_ = os.Rename(backupSkillDir, targetSkillDir)
+		}
+		return fmt.Errorf("failed to replace skill directory: %w", err)
+	}
+
+	if backupCreated {
+		if err := os.RemoveAll(backupSkillDir); err != nil {
+			return fmt.Errorf("failed to clean backup skill directory: %w", err)
+		}
+	}
 	return nil
 }
 
@@ -694,7 +790,7 @@ func (s *SkillService) QuerySkill(skillName, outputDir, version, label, md5 stri
 		return nil, err
 	}
 	if result.Updated {
-		if err := extractZip(result.ZipBytes, outputDir); err != nil {
+		if err := replaceSkillFromZip(result.ZipBytes, outputDir, skillName); err != nil {
 			return nil, fmt.Errorf("failed to extract skill: %w", err)
 		}
 	}

--- a/internal/skill/skill_service.go
+++ b/internal/skill/skill_service.go
@@ -488,11 +488,6 @@ func replaceSkillFromZip(zipBytes []byte, outputDir, skillName string) (retErr e
 	return nil
 }
 
-// extractZip preserves the existing private helper name for older call sites in this package.
-func extractZip(zipBytes []byte, targetDir string) error {
-	return ExtractSkillZip(zipBytes, targetDir)
-}
-
 // UploadSkill uploads a skill draft from local directory or a pre-built zip file.
 // If skillPath points to a .zip file it is uploaded directly; otherwise the
 // directory is packed into a zip on-the-fly with files at the archive root.

--- a/internal/skill/skill_service.go
+++ b/internal/skill/skill_service.go
@@ -431,7 +431,7 @@ func validateSkillZip(zipBytes []byte, skillName string) error {
 	return nil
 }
 
-func replaceSkillFromZip(zipBytes []byte, outputDir, skillName string) error {
+func replaceSkillFromZip(zipBytes []byte, outputDir, skillName string) (retErr error) {
 	if err := validateSkillZip(zipBytes, skillName); err != nil {
 		return err
 	}
@@ -443,7 +443,11 @@ func replaceSkillFromZip(zipBytes []byte, outputDir, skillName string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create temp directory: %w", err)
 	}
-	defer os.RemoveAll(stageRoot)
+	defer func() {
+		if err := os.RemoveAll(stageRoot); err != nil && retErr == nil {
+			retErr = fmt.Errorf("failed to clean temp directory: %w", err)
+		}
+	}()
 
 	if err := ExtractSkillZip(zipBytes, stageRoot); err != nil {
 		return err
@@ -469,7 +473,9 @@ func replaceSkillFromZip(zipBytes []byte, outputDir, skillName string) error {
 
 	if err := os.Rename(stagedSkillDir, targetSkillDir); err != nil {
 		if backupCreated {
-			_ = os.Rename(backupSkillDir, targetSkillDir)
+			if rollbackErr := os.Rename(backupSkillDir, targetSkillDir); rollbackErr != nil {
+				return fmt.Errorf("failed to replace skill directory: %w; rollback failed: %v", err, rollbackErr)
+			}
 		}
 		return fmt.Errorf("failed to replace skill directory: %w", err)
 	}

--- a/internal/skill/skill_service_test.go
+++ b/internal/skill/skill_service_test.go
@@ -386,3 +386,97 @@ func TestUploadSkillZipPaths(t *testing.T) {
 		}
 	}
 }
+
+func TestReplaceSkillFromZipRemovesStaleFiles(t *testing.T) {
+	outputDir := t.TempDir()
+	skillDir := filepath.Join(outputDir, "demo")
+	if err := os.MkdirAll(filepath.Join(skillDir, "assets"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("# Old\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "assets", "old.txt"), []byte("stale\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	zipBytes := makeSkillZip(t, "demo", map[string]string{
+		"SKILL.md":       "# New\n",
+		"assets/new.txt": "fresh\n",
+		"prompts/a.txt":  "hello\n",
+	})
+
+	if err := replaceSkillFromZip(zipBytes, outputDir, "demo"); err != nil {
+		t.Fatalf("replaceSkillFromZip: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(skillDir, "assets", "old.txt")); !os.IsNotExist(err) {
+		t.Fatalf("stale file still exists, stat err = %v", err)
+	}
+	body, err := os.ReadFile(filepath.Join(skillDir, "SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != "# New\n" {
+		t.Fatalf("SKILL.md = %q, want %q", string(body), "# New\n")
+	}
+	if _, err := os.Stat(filepath.Join(skillDir, "assets", "new.txt")); err != nil {
+		t.Fatalf("new asset missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(skillDir, "prompts", "a.txt")); err != nil {
+		t.Fatalf("new prompt missing: %v", err)
+	}
+}
+
+func TestReplaceSkillFromZipRejectsUnexpectedRootAndKeepsExistingFiles(t *testing.T) {
+	outputDir := t.TempDir()
+	skillDir := filepath.Join(outputDir, "demo")
+	if err := os.MkdirAll(filepath.Join(skillDir, "assets"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("# Original\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "assets", "keep.txt"), []byte("keep\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	zipBytes := makeSkillZip(t, "other", map[string]string{
+		"SKILL.md": "wrong root\n",
+	})
+
+	err := replaceSkillFromZip(zipBytes, outputDir, "demo")
+	if err == nil {
+		t.Fatal("expected error for unexpected zip root")
+	}
+
+	body, readErr := os.ReadFile(filepath.Join(skillDir, "SKILL.md"))
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(body) != "# Original\n" {
+		t.Fatalf("SKILL.md changed to %q", string(body))
+	}
+	if _, statErr := os.Stat(filepath.Join(skillDir, "assets", "keep.txt")); statErr != nil {
+		t.Fatalf("existing file missing after failed replace: %v", statErr)
+	}
+}
+
+func makeSkillZip(t *testing.T, skillName string, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for relPath, content := range files {
+		writer, err := zw.Create(skillName + "/" + filepath.ToSlash(relPath))
+		if err != nil {
+			t.Fatalf("create zip entry %q: %v", relPath, err)
+		}
+		if _, err := writer.Write([]byte(content)); err != nil {
+			t.Fatalf("write zip entry %q: %v", relPath, err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("close zip: %v", err)
+	}
+	return buf.Bytes()
+}


### PR DESCRIPTION
## 背景

当前 `skill-get` 在下载 skill 时，使用的是原地解压覆盖的方式。

这种方式可以更新 ZIP 中仍然存在的文件，但不会删除旧版本本地目录中那些已经被远端移除、且新 ZIP 中不再存在的文件。因此在 skill 更新后，本地目录可能残留陈旧文件，导致本地内容与远端实际包内容不一致。

Related to #83 

## 改动内容

本次将 `skill-get` 的下载/更新逻辑调整为“临时目录解压 + 整目录替换”：

- 下载 ZIP 后，先解压到临时目录
- 校验 ZIP 结构是否合法
- 要求 ZIP 内容必须位于目标 `skillName/` 顶层目录下
- 要求 ZIP 中必须包含 `skillName/SKILL.md`
- 如果本地目标目录已存在，先重命名为备份目录
- 再将新目录整体替换到正式路径
- 替换成功后删除备份目录
- 如果替换失败，则回滚旧目录

同时将 `GetSkill` 和 `QuerySkill` 两条下载路径统一到这套目录替换逻辑上，避免不同入口行为不一致。

## 修复效果

修复后，`skill-get` 在更新 skill 时：

- 可以正确清理远端已删除但本地残留的旧文件
- 不会在新版本解压或校验失败时先破坏已有本地 skill
- 本地 skill 目录内容会与远端 ZIP 保持一致

## 测试

已补充并通过以下测试：

- 更新 skill 时会清理已删除的旧文件
- ZIP 顶层目录不合法时，不会破坏现有本地 skill

本地已执行：

```
gofmt -w internal/skill/skill_service.go internal/skill/skill_service_test.go
go test ./internal/skill/... ./cmd/...
```