### PR TITLE
[codex] Add AgentTeams STS auth compatibility

### DIFF
--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -116,20 +116,13 @@ Examples:
 			fmt.Println()
 			// Start interactive terminal with the edited config
 			var stsURLVal, stsAuthTokenVal string
-			if cfg.AuthType == "sts-hiclaw" {
-				controllerURL := os.Getenv("HICLAW_CONTROLLER_URL")
-				tokenFile := os.Getenv("HICLAW_AUTH_TOKEN_FILE")
-				if controllerURL == "" || tokenFile == "" {
-					fmt.Fprintf(os.Stderr, "Error: sts-hiclaw auth requires HICLAW_CONTROLLER_URL and HICLAW_AUTH_TOKEN_FILE environment variables\n")
+			if client.IsStsAuthType(cfg.AuthType) {
+				var stsErr error
+				stsURLVal, stsAuthTokenVal, stsErr = loadStsAuthFromEnv(cfg.AuthType)
+				if stsErr != nil {
+					fmt.Fprintf(os.Stderr, "Error: %v\n", stsErr)
 					os.Exit(1)
 				}
-				stsURLVal = strings.TrimRight(controllerURL, "/") + "/api/v1/credentials/sts"
-				data, err := os.ReadFile(tokenFile)
-				if err != nil {
-					fmt.Fprintf(os.Stderr, "Error: failed to read HICLAW_AUTH_TOKEN_FILE (%s): %v\n", tokenFile, err)
-					os.Exit(1)
-				}
-				stsAuthTokenVal = strings.TrimSpace(string(data))
 			}
 			nacosClient, err := client.NewNacosClient(
 				cfg.GetServerAddr(),
@@ -205,8 +198,9 @@ Examples:
 		case "aliyun":
 			fmt.Printf("%-15s %s\n", "access-key:", maskSensitiveValue(cfg.AccessKey))
 			fmt.Printf("%-15s %s\n", "secret-key:", maskSensitiveValue(cfg.SecretKey))
-		case "sts-hiclaw":
-			fmt.Printf("%-15s %s\n", "credentials:", "from HICLAW_CONTROLLER_URL and HICLAW_AUTH_TOKEN_FILE env vars")
+		case "sts-hiclaw", "sts-agentteams":
+			controllerEnv, tokenFileEnv := stsAuthEnvNames(cfg.AuthType)
+			fmt.Printf("%-15s from %s and %s env vars\n", "credentials:", controllerEnv, tokenFileEnv)
 		default:
 			fmt.Printf("%-15s %s\n", "username:", maskSensitiveValue(cfg.Username))
 			fmt.Printf("%-15s %s\n", "password:", maskSensitiveValue(cfg.Password))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -58,7 +58,7 @@ Examples:
 		var err error
 
 		// Check if any connection parameters are provided via command line
-		hasCommandLineConfig := host != "" || port > 0 || serverAddr != "" || username != "" || password != "" || accessKey != "" || secretKey != "" || securityToken != "" || authType == "sts-hiclaw" || scheme != ""
+		hasCommandLineConfig := host != "" || port > 0 || serverAddr != "" || username != "" || password != "" || accessKey != "" || secretKey != "" || securityToken != "" || authType != "" || scheme != ""
 		envHost := strings.TrimSpace(os.Getenv("NACOS_HOST"))
 		envNamespace := strings.TrimSpace(os.Getenv("NACOS_NAMESPACE"))
 		envPortRaw := strings.TrimSpace(os.Getenv("NACOS_PORT"))
@@ -179,6 +179,14 @@ Examples:
 				authType = envAuthType
 			}
 		}
+		if authType != "" {
+			normalizedAuthType, normalizeErr := config.NormalizeAuthType(authType)
+			if normalizeErr != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", normalizeErr)
+				os.Exit(1)
+			}
+			authType = normalizedAuthType
+		}
 
 		// Username: command line > config file
 		if username == "" && fileConfig != nil && fileConfig.Username != "" {
@@ -220,29 +228,14 @@ Examples:
 			scheme = "http"
 		}
 
-		// For sts-hiclaw auth, read HICLAW_CONTROLLER_URL and HICLAW_AUTH_TOKEN_FILE from environment variables
-		if authType == "sts-hiclaw" {
-			if stsURL == "" {
-				controllerURL := os.Getenv("HICLAW_CONTROLLER_URL")
-				if controllerURL != "" {
-					stsURL = strings.TrimRight(controllerURL, "/") + "/api/v1/credentials/sts"
-				}
-			}
-			if stsAuthToken == "" {
-				tokenFile := os.Getenv("HICLAW_AUTH_TOKEN_FILE")
-				if tokenFile != "" {
-					data, err := os.ReadFile(tokenFile)
-					if err != nil {
-						fmt.Fprintf(os.Stderr, "Error: failed to read HICLAW_AUTH_TOKEN_FILE (%s): %v\n", tokenFile, err)
-						os.Exit(1)
-					}
-					stsAuthToken = strings.TrimSpace(string(data))
-				}
-			}
-			if stsURL == "" || stsAuthToken == "" {
-				fmt.Fprintf(os.Stderr, "Error: sts-hiclaw auth requires HICLAW_CONTROLLER_URL and HICLAW_AUTH_TOKEN_FILE environment variables\n")
+		if client.IsStsAuthType(authType) && (stsURL == "" || stsAuthToken == "") {
+			envStsURL, envStsAuthToken, stsErr := loadStsAuthFromEnv(authType)
+			if stsErr != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", stsErr)
 				os.Exit(1)
 			}
+			stsURL = envStsURL
+			stsAuthToken = envStsAuthToken
 		}
 
 		if verbose {
@@ -310,6 +303,27 @@ func parseNacosEnvPort(rawPort string) int {
 	return envPort
 }
 
+func loadStsAuthFromEnv(authType string) (string, string, error) {
+	controllerEnv, tokenFileEnv := stsAuthEnvNames(authType)
+	controllerURL := os.Getenv(controllerEnv)
+	tokenFile := os.Getenv(tokenFileEnv)
+	if controllerURL == "" || tokenFile == "" {
+		return "", "", fmt.Errorf("%s auth requires %s and %s environment variables", authType, controllerEnv, tokenFileEnv)
+	}
+	data, err := os.ReadFile(tokenFile)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to read %s (%s): %w", tokenFileEnv, tokenFile, err)
+	}
+	return strings.TrimRight(controllerURL, "/") + "/api/v1/credentials/sts", strings.TrimSpace(string(data)), nil
+}
+
+func stsAuthEnvNames(authType string) (string, string) {
+	if authType == client.AuthTypeStsAgentTeams {
+		return "AGENTTEAMS_CONTROLLER_URL", "AGENTTEAMS_AUTH_TOKEN_FILE"
+	}
+	return "HICLAW_CONTROLLER_URL", "HICLAW_AUTH_TOKEN_FILE"
+}
+
 func init() {
 	// Global flags - new style
 	rootCmd.PersistentFlags().StringVar(&host, "host", "", "Nacos server host (default: market.hiclaw.io)")
@@ -322,12 +336,12 @@ func init() {
 	// Global flags - legacy style (for backward compatibility)
 	rootCmd.PersistentFlags().StringVarP(&serverAddr, "server", "s", "", "Nacos server address (e.g., market.hiclaw.io:80)")
 	rootCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "", "Namespace ID")
-	rootCmd.PersistentFlags().StringVar(&authType, "auth-type", "", "Auth type: nacos | aliyun | sts-hiclaw")
+	rootCmd.PersistentFlags().StringVar(&authType, "auth-type", "", "Auth type: nacos | aliyun | sts-hiclaw | sts-agentteams")
 	rootCmd.PersistentFlags().StringVarP(&username, "username", "u", "", "Username (nacos auth)")
 	rootCmd.PersistentFlags().StringVarP(&password, "password", "p", "", "Password (nacos auth)")
-	rootCmd.PersistentFlags().StringVar(&accessKey, "access-key", "", "AccessKey (aliyun/sts-hiclaw auth)")
-	rootCmd.PersistentFlags().StringVar(&secretKey, "secret-key", "", "SecretKey (aliyun/sts-hiclaw auth)")
-	rootCmd.PersistentFlags().StringVar(&securityToken, "security-token", "", "STS SecurityToken (sts-hiclaw auth)")
+	rootCmd.PersistentFlags().StringVar(&accessKey, "access-key", "", "AccessKey (aliyun/STS auth)")
+	rootCmd.PersistentFlags().StringVar(&secretKey, "secret-key", "", "SecretKey (aliyun/STS auth)")
+	rootCmd.PersistentFlags().StringVar(&securityToken, "security-token", "", "STS SecurityToken (STS auth)")
 	rootCmd.PersistentFlags().BoolVar(&verbose, "verbose", false, "Enable verbose/debug output")
 
 	// Mark legacy server flag as deprecated but still functional

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -58,7 +58,7 @@ Examples:
 		var err error
 
 		// Check if any connection parameters are provided via command line
-		hasCommandLineConfig := host != "" || port > 0 || serverAddr != "" || username != "" || password != "" || accessKey != "" || secretKey != "" || securityToken != "" || authType != "" || scheme != ""
+		hasCommandLineConfig := host != "" || port > 0 || serverAddr != "" || username != "" || password != "" || accessKey != "" || secretKey != "" || securityToken != "" || isCommandLineStsAuthType(authType) || scheme != ""
 		envHost := strings.TrimSpace(os.Getenv("NACOS_HOST"))
 		envNamespace := strings.TrimSpace(os.Getenv("NACOS_NAMESPACE"))
 		envPortRaw := strings.TrimSpace(os.Getenv("NACOS_PORT"))
@@ -274,6 +274,14 @@ func isSkillSyncCommand(cmd *cobra.Command) bool {
 		strings.HasPrefix(path, "nacos-cli skill-sync ") ||
 		path == "skill-sync" ||
 		strings.HasPrefix(path, "skill-sync ")
+}
+
+func isCommandLineStsAuthType(value string) bool {
+	authType, err := config.NormalizeAuthType(value)
+	if err != nil {
+		return false
+	}
+	return client.IsStsAuthType(authType)
 }
 
 // SetVersionInfo sets the version information for the root command.

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -127,6 +127,42 @@ func TestPersistentPreRunStsAgentTeamsUsesAgentTeamsEnv(t *testing.T) {
 	}
 }
 
+func TestPersistentPreRunAuthTypeOverrideKeepsProfileConfig(t *testing.T) {
+	resetRootConfigForTest(t)
+	t.Setenv("HOME", t.TempDir())
+
+	profilePath, err := config.GetProfileConfigPath("dev")
+	if err != nil {
+		t.Fatalf("get profile path: %v", err)
+	}
+	cfg := &config.Config{
+		Host:      "10.0.0.2",
+		Port:      8848,
+		AuthType:  "none",
+		AccessKey: "profile-ak",
+		SecretKey: "profile-sk",
+	}
+	if err := cfg.SaveConfig(profilePath); err != nil {
+		t.Fatalf("save profile: %v", err)
+	}
+	if err := config.SetCurrentProfile("dev"); err != nil {
+		t.Fatalf("set current profile: %v", err)
+	}
+	authType = "aliyun"
+
+	rootCmd.PersistentPreRun(&cobra.Command{Use: "skill-list"}, nil)
+
+	if serverAddr != "10.0.0.2:8848" {
+		t.Fatalf("serverAddr = %q, want %q", serverAddr, "10.0.0.2:8848")
+	}
+	if authType != "aliyun" {
+		t.Fatalf("authType = %q, want aliyun", authType)
+	}
+	if accessKey != "profile-ak" || secretKey != "profile-sk" {
+		t.Fatalf("profile credentials not loaded: accessKey=%q secretKey=%q", accessKey, secretKey)
+	}
+}
+
 func TestSchemePriority_HttpHostOverridesProfileHttps(t *testing.T) {
 	resetRootConfigForTest(t)
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -99,6 +99,34 @@ func TestPersistentPreRunDoesNotAutoDetectStsHiclaw(t *testing.T) {
 	}
 }
 
+func TestPersistentPreRunStsAgentTeamsUsesAgentTeamsEnv(t *testing.T) {
+	resetRootConfigForTest(t)
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("NACOS_HOST", "127.0.0.1")
+	t.Setenv("NACOS_AUTH_TYPE", "sts-agentteams")
+	t.Setenv("HICLAW_CONTROLLER_URL", "http://hiclaw-controller")
+	t.Setenv("HICLAW_AUTH_TOKEN_FILE", filepath.Join(t.TempDir(), "hiclaw-token"))
+
+	tokenFile := filepath.Join(t.TempDir(), "agentteams-token")
+	if err := os.WriteFile(tokenFile, []byte("agentteams-token\n"), 0600); err != nil {
+		t.Fatalf("write token: %v", err)
+	}
+	t.Setenv("AGENTTEAMS_CONTROLLER_URL", "http://agentteams-controller/")
+	t.Setenv("AGENTTEAMS_AUTH_TOKEN_FILE", tokenFile)
+
+	rootCmd.PersistentPreRun(&cobra.Command{Use: "skill-list"}, nil)
+
+	if authType != "sts-agentteams" {
+		t.Fatalf("authType = %q, want sts-agentteams", authType)
+	}
+	if stsURL != "http://agentteams-controller/api/v1/credentials/sts" {
+		t.Fatalf("stsURL = %q, want agentteams controller STS URL", stsURL)
+	}
+	if stsAuthToken != "agentteams-token" {
+		t.Fatalf("stsAuthToken = %q, want agentteams-token", stsAuthToken)
+	}
+}
+
 func TestSchemePriority_HttpHostOverridesProfileHttps(t *testing.T) {
 	resetRootConfigForTest(t)
 

--- a/internal/client/nacos_client.go
+++ b/internal/client/nacos_client.go
@@ -18,10 +18,11 @@ import (
 )
 
 const (
-	AuthTypeNone     = "none"       // No authentication (public registry)
-	AuthTypeNacos    = "nacos"      // Username/password authentication
-	AuthTypeAliyun   = "aliyun"     // AccessKey/SecretKey authentication
-	AuthTypeStsToken = "sts-hiclaw" // STS temporary credential via Hiclaw controller
+	AuthTypeNone          = "none"           // No authentication (public registry)
+	AuthTypeNacos         = "nacos"          // Username/password authentication
+	AuthTypeAliyun        = "aliyun"         // AccessKey/SecretKey authentication
+	AuthTypeStsToken      = "sts-hiclaw"     // STS temporary credential via Hiclaw controller
+	AuthTypeStsAgentTeams = "sts-agentteams" // STS temporary credential via AgentTeams controller
 )
 
 const DefaultHTTPTimeout = 30 * time.Second
@@ -51,8 +52,8 @@ type NacosClient struct {
 	AccessKey        string
 	SecretKey        string
 	SecurityToken    string // STS temporary security token
-	StsURL           string // STS credential endpoint URL (AuthType=sts-hiclaw)
-	StsAuthToken     string // Bearer token for Hiclaw controller authentication
+	StsURL           string // STS credential endpoint URL
+	StsAuthToken     string // Bearer token for controller authentication
 	AccessToken      string
 	TokenExpireAt    time.Time
 	stsCredExpireAt  time.Time // expiration time of STS credentials
@@ -60,6 +61,10 @@ type NacosClient struct {
 	httpClient       *resty.Client
 	rawHTTPClient    *http.Client
 	Verbose          bool // Enable verbose/debug output
+}
+
+func IsStsAuthType(authType string) bool {
+	return authType == AuthTypeStsToken || authType == AuthTypeStsAgentTeams
 }
 
 // Config represents a Nacos configuration
@@ -185,7 +190,7 @@ func NewNacosClient(serverAddr, namespace, authType, username, password, accessK
 		if err := c.login(); err != nil {
 			return nil, fmt.Errorf("login failed: %w", err)
 		}
-	case AuthTypeStsToken:
+	case AuthTypeStsToken, AuthTypeStsAgentTeams:
 		if c.StsURL != "" {
 			if err := c.fetchStsCredentials(); err != nil {
 				return nil, fmt.Errorf("fetch STS credentials failed: %w", err)
@@ -306,9 +311,10 @@ func (c *NacosClient) applyLoginFromMap(m map[string]interface{}) bool {
 
 // EnsureTokenValid ensures the access token / STS credentials are valid, refreshing if necessary
 func (c *NacosClient) EnsureTokenValid() error {
-	switch c.AuthType {
-	case AuthTypeStsToken:
+	if IsStsAuthType(c.AuthType) {
 		return c.ensureStsCredentials()
+	}
+	switch c.AuthType {
 	case AuthTypeNacos:
 		if c.AccessToken == "" {
 			return c.login()
@@ -334,7 +340,7 @@ func (c *NacosClient) ensureStsCredentials() error {
 	return nil
 }
 
-// doWithStsRetry runs build(); if the response is 401/403 under sts-hiclaw auth,
+// doWithStsRetry runs build(); if the response is 401/403 under STS auth,
 // it forces an STS credential refresh and invokes build() once more. The closure
 // must rebuild the request each call so the SPAS signature picks up the refreshed
 // credentials and a current timestamp.
@@ -343,37 +349,37 @@ func (c *NacosClient) doWithStsRetry(build func() (*resty.Response, error)) (*re
 	if err != nil {
 		return resp, err
 	}
-	if c.AuthType != AuthTypeStsToken {
+	if !IsStsAuthType(c.AuthType) {
 		return resp, nil
 	}
 	if resp.StatusCode() != 401 && resp.StatusCode() != 403 {
 		return resp, nil
 	}
-	fmt.Fprintf(os.Stderr, "[info] sts-hiclaw: request returned HTTP %d, refreshing credentials and retrying once\n", resp.StatusCode())
+	fmt.Fprintf(os.Stderr, "[info] %s: request returned HTTP %d, refreshing credentials and retrying once\n", c.AuthType, resp.StatusCode())
 	if refreshErr := c.fetchStsCredentials(); refreshErr != nil {
-		fmt.Fprintf(os.Stderr, "[warn] sts-hiclaw: credential refresh failed during retry: %v\n", refreshErr)
+		fmt.Fprintf(os.Stderr, "[warn] %s: credential refresh failed during retry: %v\n", c.AuthType, refreshErr)
 		return resp, nil
 	}
 	retryResp, retryErr := build()
 	if retryErr != nil {
-		fmt.Fprintf(os.Stderr, "[warn] sts-hiclaw: retry after credential refresh failed: %v\n", retryErr)
+		fmt.Fprintf(os.Stderr, "[warn] %s: retry after credential refresh failed: %v\n", c.AuthType, retryErr)
 	} else {
-		fmt.Fprintf(os.Stderr, "[info] sts-hiclaw: retry after credential refresh returned HTTP %d\n", retryResp.StatusCode())
+		fmt.Fprintf(os.Stderr, "[info] %s: retry after credential refresh returned HTTP %d\n", c.AuthType, retryResp.StatusCode())
 	}
 	return retryResp, retryErr
 }
 
 // fetchStsCredentials calls the STS URL to obtain temporary AK/SK/SecurityToken
 func (c *NacosClient) fetchStsCredentials() error {
-	fmt.Fprintf(os.Stderr, "[info] sts-hiclaw: fetching STS credentials from %s\n", c.StsURL)
+	fmt.Fprintf(os.Stderr, "[info] %s: fetching STS credentials from %s\n", c.AuthType, c.StsURL)
 	req := c.httpClient.R().
 		SetHeader("Authorization", "Bearer "+c.StsAuthToken)
-	if clusterID := os.Getenv("HICLAW_CLUSTER_ID"); clusterID != "" {
+	if clusterID := os.Getenv(c.stsClusterIDEnvName()); clusterID != "" {
 		req.SetHeader("X-HiClaw-Cluster-ID", clusterID)
 	}
 	resp, err := req.Post(c.StsURL)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "[warn] sts-hiclaw: STS request failed: %v\n", err)
+		fmt.Fprintf(os.Stderr, "[warn] %s: STS request failed: %v\n", c.AuthType, err)
 		return fmt.Errorf("request STS URL failed: %w", err)
 	}
 	if c.Verbose {
@@ -381,7 +387,7 @@ func (c *NacosClient) fetchStsCredentials() error {
 		fmt.Fprintf(os.Stderr, "[debug] STS response body length: %d\n", len(resp.Body()))
 	}
 	if resp.StatusCode() != 200 {
-		fmt.Fprintf(os.Stderr, "[warn] sts-hiclaw: STS endpoint returned HTTP %d\n", resp.StatusCode())
+		fmt.Fprintf(os.Stderr, "[warn] %s: STS endpoint returned HTTP %d\n", c.AuthType, resp.StatusCode())
 		return fmt.Errorf("STS URL returned HTTP %d: %s", resp.StatusCode(), string(resp.Body()))
 	}
 	var stsResp stsTokenResponse
@@ -407,9 +413,16 @@ func (c *NacosClient) fetchStsCredentials() error {
 		fmt.Fprintf(os.Stderr, "[warn] STS response missing expires_in_sec and expiration, falling back to default TTL %s\n", defaultStsCredTTL)
 		c.stsCredExpireAt = time.Now().Add(defaultStsCredTTL)
 	}
-	fmt.Fprintf(os.Stderr, "[info] sts-hiclaw: STS credentials refreshed (accessKey=%s, expires=%s)\n",
-		maskAccessKey(c.AccessKey), c.stsCredExpireAt.Format(time.RFC3339))
+	fmt.Fprintf(os.Stderr, "[info] %s: STS credentials refreshed (accessKey=%s, expires=%s)\n",
+		c.AuthType, maskAccessKey(c.AccessKey), c.stsCredExpireAt.Format(time.RFC3339))
 	return nil
+}
+
+func (c *NacosClient) stsClusterIDEnvName() string {
+	if c.AuthType == AuthTypeStsAgentTeams {
+		return "AGENTTEAMS_CLUSTER_ID"
+	}
+	return "HICLAW_CLUSTER_ID"
 }
 
 // maskAccessKey returns a short masked form of an access key for logs (first 8 chars + ...).
@@ -445,7 +458,7 @@ func spasSign(signData, secretKey string) string {
 const aiResourceGroup = "DEFAULT_GROUP"
 
 // NewAuthedRequest creates an *http.Request with authentication headers already applied.
-// It sets the Bearer token header for nacos auth and SPAS headers for aliyun/sts-hiclaw auth.
+// It sets the Bearer token header for nacos auth and SPAS headers for aliyun/STS auth.
 // AI resource APIs (skill, agentspec) use namespaceId as tenant and DEFAULT_GROUP as group
 // for SPAS signature calculation.
 func (c *NacosClient) NewAuthedRequest(method, url string, body io.Reader) (*http.Request, error) {
@@ -457,8 +470,8 @@ func (c *NacosClient) NewAuthedRequest(method, url string, body io.Reader) (*htt
 	if c.AccessToken != "" {
 		req.Header.Set("Authorization", "Bearer "+c.AccessToken)
 	}
-	// SPAS headers (aliyun/sts-hiclaw auth): tenant=namespaceId, group=DEFAULT_GROUP
-	if (c.AuthType == AuthTypeAliyun || c.AuthType == AuthTypeStsToken) && c.AccessKey != "" && c.SecretKey != "" {
+	// SPAS headers (aliyun/STS auth): tenant=namespaceId, group=DEFAULT_GROUP
+	if (c.AuthType == AuthTypeAliyun || IsStsAuthType(c.AuthType)) && c.AccessKey != "" && c.SecretKey != "" {
 		ts := strconv.FormatInt(time.Now().UnixMilli(), 10)
 		tenant := c.Namespace
 		if tenant == "public" {
@@ -468,7 +481,7 @@ func (c *NacosClient) NewAuthedRequest(method, url string, body io.Reader) (*htt
 		req.Header.Set("timeStamp", ts)
 		req.Header.Set("Spas-AccessKey", c.AccessKey)
 		req.Header.Set("Spas-Signature", spasSign(signData, c.SecretKey))
-		if c.AuthType == AuthTypeStsToken && c.SecurityToken != "" {
+		if IsStsAuthType(c.AuthType) && c.SecurityToken != "" {
 			req.Header.Set("Spas-SecurityToken", c.SecurityToken)
 		}
 		if c.Verbose {
@@ -484,7 +497,7 @@ func (c *NacosClient) NewAuthedRequest(method, url string, body io.Reader) (*htt
 
 // setSpasHeaders sets Aliyun/STS authentication headers for SPAS signature
 func (c *NacosClient) setSpasHeaders(req *resty.Request, tenant, group string) {
-	if (c.AuthType != AuthTypeAliyun && c.AuthType != AuthTypeStsToken) || c.AccessKey == "" || c.SecretKey == "" {
+	if (c.AuthType != AuthTypeAliyun && !IsStsAuthType(c.AuthType)) || c.AccessKey == "" || c.SecretKey == "" {
 		return
 	}
 	ts := strconv.FormatInt(time.Now().UnixMilli(), 10)
@@ -496,7 +509,7 @@ func (c *NacosClient) setSpasHeaders(req *resty.Request, tenant, group string) {
 	}
 	signData := getSignData(normalizedTenant, group, ts)
 	req.SetHeader("Spas-Signature", spasSign(signData, c.SecretKey))
-	if c.AuthType == AuthTypeStsToken && c.SecurityToken != "" {
+	if IsStsAuthType(c.AuthType) && c.SecurityToken != "" {
 		req.SetHeader("Spas-SecurityToken", c.SecurityToken)
 	}
 }

--- a/internal/client/nacos_client_test.go
+++ b/internal/client/nacos_client_test.go
@@ -132,6 +132,31 @@ func TestFetchStsCredentialsSendsClusterIDHeader(t *testing.T) {
 	}
 }
 
+func TestFetchStsCredentialsSendsAgentTeamsClusterIDHeader(t *testing.T) {
+	t.Setenv("AGENTTEAMS_CLUSTER_ID", "agentteams-cluster")
+	t.Setenv("HICLAW_CLUSTER_ID", "hiclaw-cluster")
+
+	stsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("X-HiClaw-Cluster-ID"); got != "agentteams-cluster" {
+			t.Fatalf("X-HiClaw-Cluster-ID = %q, want %q", got, "agentteams-cluster")
+		}
+		_, _ = w.Write([]byte(`{"access_key_id":"ak","access_key_secret":"sk","security_token":"st","expires_in_sec":60}`))
+	}))
+	defer stsServer.Close()
+
+	if _, err := NewNacosClient(
+		"localhost:8848",
+		"public",
+		AuthTypeStsAgentTeams,
+		"", "", "", "", "",
+		stsServer.URL,
+		"auth-token",
+		"http",
+	); err != nil {
+		t.Fatalf("NewNacosClient() error = %v", err)
+	}
+}
+
 func TestNacosClientReusesHTTPClientWithTimeout(t *testing.T) {
 	c, err := NewNacosClient(
 		"127.0.0.1:8848",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,7 +25,7 @@ type Config struct {
 	Host          string `yaml:"host"`
 	Port          int    `yaml:"port"`
 	Scheme        string `yaml:"scheme"`   // http | https (default: http)
-	AuthType      string `yaml:"authType"` // nacos | aliyun | sts-hiclaw
+	AuthType      string `yaml:"authType"` // nacos | aliyun | sts-hiclaw | sts-agentteams
 	Username      string `yaml:"username"`
 	Password      string `yaml:"password"`
 	AccessKey     string `yaml:"accessKey"`     // Aliyun AK (AuthType=aliyun)
@@ -305,8 +305,8 @@ func (c *Config) IsComplete() bool {
 		return c.AccessKey != "" && c.SecretKey != ""
 	}
 
-	if authType == "sts-url" || authType == "sts-hiclaw" {
-		// sts-hiclaw credentials are fetched dynamically from HICLAW_CONTROLLER_URL env var
+	if isStsAuthType(authType) {
+		// STS credentials are fetched dynamically from controller env vars.
 		return true
 	}
 
@@ -336,8 +336,8 @@ func (c *Config) GetMissingFields() []string {
 		if c.SecretKey == "" {
 			missing = append(missing, "secretKey")
 		}
-	} else if authType == "sts-url" || authType == "sts-hiclaw" {
-		// sts-hiclaw credentials are fetched dynamically; no config fields required
+	} else if isStsAuthType(authType) {
+		// STS credentials are fetched dynamically; no config fields required
 	} else {
 		// Nacos auth
 		if c.Username == "" {
@@ -499,11 +499,15 @@ func NormalizeAuthType(authType string) (string, error) {
 		return "sts-hiclaw", nil
 	}
 	switch authType {
-	case "none", "nacos", "aliyun", "sts-hiclaw":
+	case "none", "nacos", "aliyun", "sts-hiclaw", "sts-agentteams":
 		return authType, nil
 	default:
-		return "", fmt.Errorf("invalid auth type: %s (must be 'none', 'nacos', 'aliyun' or 'sts-hiclaw')", authType)
+		return "", fmt.Errorf("invalid auth type: %s (must be 'none', 'nacos', 'aliyun', 'sts-hiclaw' or 'sts-agentteams')", authType)
 	}
+}
+
+func isStsAuthType(authType string) bool {
+	return authType == "sts-url" || authType == "sts-hiclaw" || authType == "sts-agentteams"
 }
 
 func normalizeConfigKey(key string) string {
@@ -622,7 +626,7 @@ func (c *Config) PromptForMissingFields() error {
 
 	// Prompt for auth type if not set
 	if c.AuthType == "" {
-		fmt.Print("Enter auth type (none/nacos/aliyun/sts-hiclaw) [none]: ")
+		fmt.Print("Enter auth type (none/nacos/aliyun/sts-hiclaw/sts-agentteams) [none]: ")
 		input, err := reader.ReadString('\n')
 		if err != nil {
 			return fmt.Errorf("failed to read auth type: %w", err)
@@ -630,13 +634,13 @@ func (c *Config) PromptForMissingFields() error {
 		input = strings.TrimSpace(strings.ToLower(input))
 		if input == "" {
 			c.AuthType = "none"
-		} else if input == "none" || input == "nacos" || input == "aliyun" || input == "sts-hiclaw" || input == "sts-url" {
+		} else if input == "none" || input == "nacos" || input == "aliyun" || input == "sts-hiclaw" || input == "sts-agentteams" || input == "sts-url" {
 			if input == "sts-url" {
 				input = "sts-hiclaw"
 			}
 			c.AuthType = input
 		} else {
-			return fmt.Errorf("invalid auth type: %s (must be 'none', 'nacos', 'aliyun' or 'sts-hiclaw')", input)
+			return fmt.Errorf("invalid auth type: %s (must be 'none', 'nacos', 'aliyun', 'sts-hiclaw' or 'sts-agentteams')", input)
 		}
 	}
 
@@ -835,15 +839,15 @@ func (c *Config) PromptForUpdate() error {
 	if currentAuthType == "" {
 		currentAuthType = "none"
 	}
-	fmt.Printf("Enter auth type (none/nacos/aliyun/sts-hiclaw) [%s]: ", currentAuthType)
+	fmt.Printf("Enter auth type (none/nacos/aliyun/sts-hiclaw/sts-agentteams) [%s]: ", currentAuthType)
 	input, err = reader.ReadString('\n')
 	if err != nil {
 		return fmt.Errorf("failed to read auth type: %w", err)
 	}
 	input = strings.TrimSpace(strings.ToLower(input))
 	if input != "" {
-		if input != "none" && input != "nacos" && input != "aliyun" && input != "sts-hiclaw" && input != "sts-url" {
-			return fmt.Errorf("invalid auth type: %s (must be 'none', 'nacos', 'aliyun' or 'sts-hiclaw')", input)
+		if input != "none" && input != "nacos" && input != "aliyun" && input != "sts-hiclaw" && input != "sts-agentteams" && input != "sts-url" {
+			return fmt.Errorf("invalid auth type: %s (must be 'none', 'nacos', 'aliyun', 'sts-hiclaw' or 'sts-agentteams')", input)
 		}
 		if input == "sts-url" {
 			input = "sts-hiclaw"
@@ -887,9 +891,12 @@ func (c *Config) PromptForUpdate() error {
 		if c.SecretKey == "" {
 			return fmt.Errorf("secret key is required for %s auth", c.AuthType)
 		}
-	} else if c.AuthType == "sts-hiclaw" {
-		// sts-hiclaw: credentials fetched dynamically from HICLAW_CONTROLLER_URL env var
-		fmt.Println("Note: sts-hiclaw credentials are obtained from HICLAW_CONTROLLER_URL and HICLAW_AUTH_TOKEN_FILE environment variables.")
+	} else if isStsAuthType(c.AuthType) {
+		if c.AuthType == "sts-agentteams" {
+			fmt.Println("Note: sts-agentteams credentials are obtained from AGENTTEAMS_CONTROLLER_URL and AGENTTEAMS_AUTH_TOKEN_FILE environment variables.")
+		} else {
+			fmt.Println("Note: sts-hiclaw credentials are obtained from HICLAW_CONTROLLER_URL and HICLAW_AUTH_TOKEN_FILE environment variables.")
+		}
 	} else if c.AuthType == "nacos" {
 		// Nacos auth - Username
 		currentUser := formatCurrent(c.Username, true)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -368,3 +368,21 @@ func TestConfigSetValueAndGetValue(t *testing.T) {
 		t.Fatalf("server value=%q sensitive=%v", value, sensitive)
 	}
 }
+
+func TestNormalizeAuthTypeAcceptsStsAgentTeams(t *testing.T) {
+	authType, err := NormalizeAuthType("STS-AgentTeams")
+	if err != nil {
+		t.Fatalf("NormalizeAuthType() error = %v", err)
+	}
+	if authType != "sts-agentteams" {
+		t.Fatalf("auth type = %q, want sts-agentteams", authType)
+	}
+
+	cfg := Config{Host: "127.0.0.1", AuthType: authType}
+	if !cfg.IsComplete() {
+		t.Fatalf("sts-agentteams config should be complete without local credentials")
+	}
+	if missing := cfg.GetMissingFields(); len(missing) != 0 {
+		t.Fatalf("missing fields = %v, want none", missing)
+	}
+}

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -414,9 +414,9 @@ func (t *Terminal) printWelcome() {
 		if t.client.AccessKey != "" {
 			fmt.Printf("\033[33mUser:\033[0m %s (AccessKey)\n", t.client.AccessKey)
 		}
-	case client.AuthTypeStsToken:
+	case client.AuthTypeStsToken, client.AuthTypeStsAgentTeams:
 		if t.client.AccessKey != "" {
-			fmt.Printf("\033[33mUser:\033[0m %s (STS-HICLAW)\n", t.client.AccessKey)
+			fmt.Printf("\033[33mUser:\033[0m %s (%s)\n", t.client.AccessKey, strings.ToUpper(t.client.AuthType))
 		}
 	case client.AuthTypeNone:
 		fmt.Printf("\033[33mAuth:\033[0m None (public access)\n")
@@ -744,11 +744,11 @@ func (t *Terminal) getAuthTypeDisplay() string {
 			return fmt.Sprintf("aliyun (accessKey: %s...)", t.client.AccessKey[:min(8, len(t.client.AccessKey))])
 		}
 		return "aliyun"
-	case client.AuthTypeStsToken:
+	case client.AuthTypeStsToken, client.AuthTypeStsAgentTeams:
 		if t.client.AccessKey != "" {
-			return fmt.Sprintf("sts-hiclaw (accessKey: %s...)", t.client.AccessKey[:min(8, len(t.client.AccessKey))])
+			return fmt.Sprintf("%s (accessKey: %s...)", t.client.AuthType, t.client.AccessKey[:min(8, len(t.client.AccessKey))])
 		}
-		return "sts-hiclaw"
+		return t.client.AuthType
 	case client.AuthTypeNone:
 		return "none (public access)"
 	default:


### PR DESCRIPTION
## Summary

Add `sts-agentteams` as an AgentTeams-compatible STS auth type while keeping the existing STS credential refresh and SPAS signing flow unchanged.

## Changes

- Accept `sts-agentteams` in CLI flags, env auth type, profile config, and interactive profile prompts.
- Read `AGENTTEAMS_CONTROLLER_URL` and `AGENTTEAMS_AUTH_TOKEN_FILE` for `sts-agentteams`.
- Read `AGENTTEAMS_CLUSTER_ID` for the optional STS cluster header in `sts-agentteams` mode.
- Keep `sts-hiclaw` behavior on the existing `HICLAW_*` variables.

## Validation

- `go test ./cmd ./internal/client ./internal/config ./internal/terminal`
- `go test ./...`
