### PR TITLE
fix: use AgentTeams cluster header for STS auth

### DIFF
--- a/internal/client/nacos_client.go
+++ b/internal/client/nacos_client.go
@@ -375,7 +375,7 @@ func (c *NacosClient) fetchStsCredentials() error {
 	req := c.httpClient.R().
 		SetHeader("Authorization", "Bearer "+c.StsAuthToken)
 	if clusterID := os.Getenv(c.stsClusterIDEnvName()); clusterID != "" {
-		req.SetHeader("X-HiClaw-Cluster-ID", clusterID)
+		req.SetHeader(c.stsClusterIDHeaderName(), clusterID)
 	}
 	resp, err := req.Post(c.StsURL)
 	if err != nil {
@@ -423,6 +423,13 @@ func (c *NacosClient) stsClusterIDEnvName() string {
 		return "AGENTTEAMS_CLUSTER_ID"
 	}
 	return "HICLAW_CLUSTER_ID"
+}
+
+func (c *NacosClient) stsClusterIDHeaderName() string {
+	if c.AuthType == AuthTypeStsAgentTeams {
+		return "X-AgentTeams-Cluster-ID"
+	}
+	return "X-HiClaw-Cluster-ID"
 }
 
 // maskAccessKey returns a short masked form of an access key for logs (first 8 chars + ...).

--- a/internal/client/nacos_client_test.go
+++ b/internal/client/nacos_client_test.go
@@ -137,8 +137,11 @@ func TestFetchStsCredentialsSendsAgentTeamsClusterIDHeader(t *testing.T) {
 	t.Setenv("HICLAW_CLUSTER_ID", "hiclaw-cluster")
 
 	stsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if got := r.Header.Get("X-HiClaw-Cluster-ID"); got != "agentteams-cluster" {
-			t.Fatalf("X-HiClaw-Cluster-ID = %q, want %q", got, "agentteams-cluster")
+		if got := r.Header.Get("X-AgentTeams-Cluster-ID"); got != "agentteams-cluster" {
+			t.Fatalf("X-AgentTeams-Cluster-ID = %q, want %q", got, "agentteams-cluster")
+		}
+		if got := r.Header.Get("X-HiClaw-Cluster-ID"); got != "" {
+			t.Fatalf("X-HiClaw-Cluster-ID = %q, want empty", got)
 		}
 		_, _ = w.Write([]byte(`{"access_key_id":"ak","access_key_secret":"sk","security_token":"st","expires_in_sec":60}`))
 	}))


### PR DESCRIPTION
## Summary
- send `X-AgentTeams-Cluster-ID` when `authType=sts-agentteams` refreshes controller-issued STS credentials
- keep `X-HiClaw-Cluster-ID` for legacy `sts-hiclaw` auth
- update the AgentTeams STS header test to reject the old header

## Tests
- `GOCACHE=/private/tmp/nacos-cli-go-cache GOMODCACHE=/private/tmp/nacos-cli-gomodcache go test ./...`

## Context
Remote AgentTeams workers set `AGENTTEAMS_CLUSTER_ID`; the CLI already reads that env for `sts-agentteams`, but it still sent the legacy `X-HiClaw-Cluster-ID` header to the controller STS endpoint. Controllers that only recognize `X-AgentTeams-Cluster-ID` reject the STS request with 401, preventing `agentspec-get` from using `authType=sts-agentteams`.
