### PR TITLE
feat(config): add config-set type flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,6 +494,16 @@ nacos-cli config-get myconfig DEFAULT_GROUP -s 127.0.0.1:8848 -u nacos -p nacos
 nacos> config-get myconfig DEFAULT_GROUP
 ```
 
+#### Set Configuration
+
+```bash
+# Publish from file
+nacos-cli config-set myconfig DEFAULT_GROUP -f ./application.yaml
+
+# Preserve config type metadata, such as yaml
+nacos-cli config-set myconfig DEFAULT_GROUP -f ./application.yaml --type yaml
+```
+
 ### Terminal Commands
 
 When in interactive terminal mode:

--- a/cmd/set_config.go
+++ b/cmd/set_config.go
@@ -5,11 +5,13 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/nacos-group/nacos-cli/internal/client"
 	"github.com/nacos-group/nacos-cli/internal/help"
 	"github.com/spf13/cobra"
 )
 
 var setConfigFile string
+var setConfigType string
 
 var setConfigCmd = &cobra.Command{
 	Use:   "config-set [dataId] [group]",
@@ -32,7 +34,7 @@ var setConfigCmd = &cobra.Command{
 		nacosClient := mustNewNacosClient()
 
 		fmt.Printf("Publishing config: %s (%s)...\n", dataID, group)
-		err = nacosClient.PublishConfig(dataID, group, content)
+		err = nacosClient.PublishConfigWithOptions(dataID, group, content, client.PublishConfigOptions{Type: setConfigType})
 		checkError(err)
 
 		fmt.Println("Configuration published successfully")
@@ -64,6 +66,7 @@ func readSetConfigContent() (string, error) {
 
 func init() {
 	setConfigCmd.Flags().StringVarP(&setConfigFile, "file", "f", "", "Path to config file (default: read from stdin)")
+	setConfigCmd.Flags().StringVarP(&setConfigType, "type", "t", "", "Nacos config type metadata (for example yaml, json, text)")
 	_ = setConfigCmd.MarkFlagFilename("file")
 	rootCmd.AddCommand(setConfigCmd)
 }

--- a/cmd/set_config_test.go
+++ b/cmd/set_config_test.go
@@ -1,0 +1,13 @@
+package cmd
+
+import "testing"
+
+func TestSetConfigCommandHasTypeFlag(t *testing.T) {
+	flag := setConfigCmd.Flags().Lookup("type")
+	if flag == nil {
+		t.Fatal("config-set should expose --type")
+	}
+	if flag.Shorthand != "t" {
+		t.Fatalf("--type shorthand = %q, want t", flag.Shorthand)
+	}
+}

--- a/internal/client/nacos_client.go
+++ b/internal/client/nacos_client.go
@@ -689,8 +689,18 @@ func (c *NacosClient) GetConfig(dataID, group string) (string, error) {
 	return config.Content, nil
 }
 
-// PublishConfig publishes a configuration
+// PublishConfigOptions contains optional metadata used when publishing config.
+type PublishConfigOptions struct {
+	Type string
+}
+
+// PublishConfig publishes a configuration.
 func (c *NacosClient) PublishConfig(dataID, group, content string) error {
+	return c.PublishConfigWithOptions(dataID, group, content, PublishConfigOptions{})
+}
+
+// PublishConfigWithOptions publishes a configuration with optional metadata.
+func (c *NacosClient) PublishConfigWithOptions(dataID, group, content string, opts PublishConfigOptions) error {
 	if err := c.EnsureTokenValid(); err != nil {
 		return err
 	}
@@ -698,6 +708,9 @@ func (c *NacosClient) PublishConfig(dataID, group, content string) error {
 		"dataId":    dataID,
 		"groupName": group,
 		"content":   content,
+	}
+	if opts.Type != "" {
+		params["type"] = opts.Type
 	}
 
 	if c.Namespace != "" {

--- a/internal/client/nacos_client_test.go
+++ b/internal/client/nacos_client_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -179,5 +180,55 @@ func TestNacosClientReusesHTTPClientWithTimeout(t *testing.T) {
 	}
 	if first.Timeout != DefaultHTTPTimeout {
 		t.Fatalf("timeout = %s, want %s", first.Timeout, DefaultHTTPTimeout)
+	}
+}
+
+func TestPublishConfigWithOptionsUsesConfigType(t *testing.T) {
+	tests := []struct {
+		name       string
+		configType string
+		want       string
+	}{
+		{name: "without config type", configType: "", want: ""},
+		{name: "with config type", configType: "yaml", want: "yaml"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/nacos/v3/admin/cs/config" {
+					t.Fatalf("path = %q, want /nacos/v3/admin/cs/config", r.URL.Path)
+				}
+				if r.Method != http.MethodPost {
+					t.Fatalf("method = %q, want POST", r.Method)
+				}
+				if err := r.ParseForm(); err != nil {
+					t.Fatalf("ParseForm() error = %v", err)
+				}
+				if got := r.PostForm.Get("type"); got != tt.want {
+					t.Fatalf("type form value = %q, want %q", got, tt.want)
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"code":0,"message":"success","data":true}`))
+			}))
+			defer server.Close()
+
+			c, err := NewNacosClient(
+				strings.TrimPrefix(server.URL, "http://"),
+				"public",
+				AuthTypeNone,
+				"", "", "", "", "", "", "",
+				"http",
+			)
+			if err != nil {
+				t.Fatalf("NewNacosClient() error = %v", err)
+			}
+
+			opts := PublishConfigOptions{Type: tt.configType}
+			if err := c.PublishConfigWithOptions("application.yaml", "DEFAULT_GROUP", "key: value", opts); err != nil {
+				t.Fatalf("PublishConfigWithOptions() error = %v", err)
+			}
+		})
 	}
 }

--- a/internal/help/help.go
+++ b/internal/help/help.go
@@ -338,6 +338,7 @@ var (
 			"dataId          Required. Configuration data ID",
 			"group           Required. Configuration group name",
 			"--file, -f      Path to config file (default: read from stdin)",
+			"--type, -t      Nacos config type metadata, for example yaml, json, text",
 		},
 		Examples: []string{
 			"# Publish from file",
@@ -347,7 +348,10 @@ var (
 			" echo 'key: value' | nacos-cli config-set app.yaml DEFAULT_GROUP",
 			"",
 			"# Publish JSON config",
-			"config-set skill.json skill_my-skill -f ./skill.json",
+			"config-set skill.json skill_my-skill -f ./skill.json --type json",
+			"",
+			"# Preserve config type metadata",
+			"config-set application.yaml DEFAULT_GROUP -f ./application.yaml --type yaml",
 		},
 	}
 

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -141,7 +141,7 @@ func interactiveCompletionSpecs() map[string]completionSpec {
 			Flags: []string{"--help", "-h"},
 		},
 		"config-set": {
-			Flags:     []string{"--help", "-h", "--file", "-f"},
+			Flags:     []string{"--help", "-h", "--file", "-f", "--type", "-t"},
 			PathFlags: pathFlags("--file", "-f"),
 		},
 	}
@@ -692,7 +692,7 @@ func (t *Terminal) showHelp() {
 	fmt.Printf("\033[32m%-20s\033[0m %-40s %-30s\n", "config-list", "List all configurations", "config-list [options]")
 	fmt.Printf("\033[32m%-20s\033[0m %-40s %-30s\n", "", "Options: --data-id, --group, --page, --size", "")
 	fmt.Printf("\033[32m%-20s\033[0m %-40s %-30s\n", "config-get", "Get configuration content", "config-get <data-id> <group>")
-	fmt.Printf("\033[32m%-20s\033[0m %-40s %-30s\n", "config-set", "Publish config (-f file or type content)", "config-set <data-id> <group> [-f <file>]")
+	fmt.Printf("\033[32m%-20s\033[0m %-40s %-30s\n", "config-set", "Publish config (-f file or type content)", "config-set <data-id> <group> [-f <file>] [--type <type>]")
 	fmt.Println()
 
 	// System
@@ -1588,15 +1588,28 @@ func (t *Terminal) listConfigs(args []string) {
 
 // setConfig publishes a configuration (interactive mode: requires --file/-f)
 func (t *Terminal) setConfig(args []string) {
-	var dataID, group, filePath string
+	var dataID, group, filePath, configType string
 
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
-		if arg == "-f" || arg == "--file" {
+		switch {
+		case arg == "-f" || arg == "--file":
 			if i+1 < len(args) {
 				i++
 				filePath = args[i]
 			}
+			continue
+		case strings.HasPrefix(arg, "--file="):
+			filePath = strings.TrimPrefix(arg, "--file=")
+			continue
+		case arg == "-t" || arg == "--type":
+			if i+1 < len(args) {
+				i++
+				configType = args[i]
+			}
+			continue
+		case strings.HasPrefix(arg, "--type="):
+			configType = strings.TrimPrefix(arg, "--type=")
 			continue
 		}
 		if dataID == "" {
@@ -1607,7 +1620,7 @@ func (t *Terminal) setConfig(args []string) {
 	}
 
 	if dataID == "" || group == "" {
-		fmt.Println("\033[31mUsage:\033[0m config-set <data-id> <group> [-f <file>]")
+		fmt.Println("\033[31mUsage:\033[0m config-set <data-id> <group> [-f <file>] [--type <type>]")
 		fmt.Println("\033[90mWithout -f: enter content in next lines, empty line to finish.\033[0m")
 		return
 	}
@@ -1653,7 +1666,7 @@ func (t *Terminal) setConfig(args []string) {
 	}
 
 	fmt.Printf("\033[90mPublishing config: \033[33m%s\033[90m (\033[33m%s\033[90m)...\033[0m\n", dataID, group)
-	if err := t.client.PublishConfig(dataID, group, content); err != nil {
+	if err := t.client.PublishConfigWithOptions(dataID, group, content, client.PublishConfigOptions{Type: configType}); err != nil {
 		fmt.Printf("\033[31mError:\033[0m %v\n", err)
 		return
 	}

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -71,6 +71,13 @@ func TestParseCommandArgs(t *testing.T) {
 			description:  "Config set with short file flag",
 		},
 		{
+			name:         "config-set with type flag",
+			input:        "config-set data-id group -f /path/to/file.yaml --type yaml",
+			expectedCmd:  "config-set",
+			expectedArgs: []string{"data-id", "group", "-f", "/path/to/file.yaml", "--type", "yaml"},
+			description:  "Config set with explicit config type flag",
+		},
+		{
 			name:         "command with home directory path",
 			input:        "skill-get my-skill -o ~/skills",
 			expectedCmd:  "skill-get",


### PR DESCRIPTION
## Summary
- add a --type/-t flag to config-set so callers can publish Nacos config type metadata explicitly
- add PublishConfigWithOptions so the client receives config metadata from callers instead of reading hidden environment state
- document --type usage and support it in interactive terminal mode

Fixes #72

## Tests
- go test ./cmd ./internal/client ./internal/terminal
- go test ./...
