### PR TITLE
[ISSUE #92] Fix skill-sync daemon profile inheritance

### DIFF
--- a/cmd/skill_sync_start.go
+++ b/cmd/skill_sync_start.go
@@ -11,7 +11,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/nacos-group/nacos-cli/internal/config"
 	"github.com/nacos-group/nacos-cli/internal/skill"
 	"github.com/spf13/cobra"
 )
@@ -648,36 +647,7 @@ func startSyncDaemonBackground() (int, string, error) {
 	}
 	defer logFile.Close()
 
-	// Build args: rerun with --foreground
-	args := []string{"skill-sync", "start", "--foreground", "--interval", syncStartInterval}
-
-	// Pass through connection config so the child can authenticate.
-	// The child process has no stdin, so it cannot prompt for missing config.
-	// We must ensure it gets a complete config path or profile.
-	if configFile != "" {
-		args = append(args, "--config", configFile)
-	} else {
-		// Resolve the effective profile name (explicit or current default)
-		effectiveProfile := profileName
-		if effectiveProfile == "" {
-			if current, err := config.GetCurrentProfile(); err == nil {
-				effectiveProfile = current
-			} else {
-				effectiveProfile = config.DefaultProfile
-			}
-		}
-		args = append(args, "--profile", effectiveProfile)
-	}
-
-	if namespace != "" {
-		args = append(args, "--namespace", namespace)
-	}
-	if scheme != "" && scheme != "http" {
-		args = append(args, "--scheme", scheme)
-	}
-	if verbose {
-		args = append(args, "--verbose")
-	}
+	args := buildSyncDaemonForegroundArgs()
 
 	cmd := exec.Command(executable, args...)
 	cmd.Stdout = logFile
@@ -698,6 +668,33 @@ func startSyncDaemonBackground() (int, string, error) {
 		return 0, "", err
 	}
 	return pid, logPath, nil
+}
+
+func buildSyncDaemonForegroundArgs() []string {
+	args := []string{"skill-sync", "start", "--foreground", "--interval", syncStartInterval}
+
+	// Pass through connection config so the child can authenticate.
+	// The child process has no stdin, so it cannot prompt for missing config.
+	if configFile != "" {
+		args = append(args, "--config", configFile)
+	} else {
+		effectiveProfile := profileName
+		if effectiveProfile == "" {
+			effectiveProfile = skill.CurrentSyncProfile()
+		}
+		args = append(args, "--profile", effectiveProfile)
+	}
+
+	if namespace != "" {
+		args = append(args, "--namespace", namespace)
+	}
+	if scheme != "" && scheme != "http" {
+		args = append(args, "--scheme", scheme)
+	}
+	if verbose {
+		args = append(args, "--verbose")
+	}
+	return args
 }
 
 func rotateSyncDaemonLogIfNeeded(logPath string) error {

--- a/cmd/skill_sync_start_test.go
+++ b/cmd/skill_sync_start_test.go
@@ -836,6 +836,40 @@ func TestSkillSyncStartDoesNotHaveAllFlag(t *testing.T) {
 	}
 }
 
+func TestBuildSyncDaemonForegroundArgsUsesCurrentSyncProfile(t *testing.T) {
+	withTempHome(t)
+
+	origProfileName := profileName
+	origConfigFile := configFile
+	origNamespace := namespace
+	origScheme := scheme
+	origVerbose := verbose
+	origInterval := syncStartInterval
+	t.Cleanup(func() {
+		profileName = origProfileName
+		configFile = origConfigFile
+		namespace = origNamespace
+		scheme = origScheme
+		verbose = origVerbose
+		syncStartInterval = origInterval
+		skill.SetCurrentSyncProfile("")
+	})
+
+	profileName = ""
+	configFile = ""
+	namespace = ""
+	scheme = ""
+	verbose = false
+	syncStartInterval = "30s"
+	skill.SetCurrentSyncProfile("team")
+
+	args := buildSyncDaemonForegroundArgs()
+	got := strings.Join(args, " ")
+	if !strings.Contains(got, "--profile team") {
+		t.Fatalf("daemon args = %q, want current sync profile", got)
+	}
+}
+
 func TestDecideStartConflictsNonInteractiveSkips(t *testing.T) {
 	decision := decideStartConflicts([]startConflict{
 		{Name: "demo", Reason: "local differs from Nacos"},


### PR DESCRIPTION
Please do not create a Pull Request without creating an issue first.

Fixes #92

## What is the purpose of the change

Fix `skill-sync start` so the background daemon inherits the active skill-sync profile resolved by the parent command. This prevents the daemon from falling back to another CLI/default profile and exiting after `start` initially reports it as running.

## Brief changelog

- Extract foreground daemon argument construction into `buildSyncDaemonForegroundArgs`.
- Use `skill.CurrentSyncProfile()` when no explicit `--profile` is passed to the parent `start` command.
- Add a regression test covering active sync profile inheritance for the background daemon.

## Verifying this change

- `GOCACHE=/private/tmp/nacos-cli-go-build go vet ./...`
- `GOCACHE=/private/tmp/nacos-cli-go-build go test -race -coverprofile=/private/tmp/nacos-cli-coverage.out ./...`

Follow this checklist to help us incorporate your contribution quickly and easily:

* [ ] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [ ] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [ ] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
