### PR TITLE
feat: support configurable Nacos token transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,6 +521,7 @@ nacos> quit           # Exit terminal
 | --host | | market.hiclaw.io when `--host` and `--port` are both omitted; otherwise 127.0.0.1 when only `--port` is provided | Nacos server host |
 | --port | | 80 when `--host` and `--port` are both omitted; otherwise 8848 when omitted after `--host` | Nacos server port |
 | --scheme | | http | Protocol scheme: `http` or `https` |
+| --token-transport | | bearer | Access-token transport: `bearer`, `authorization`, `header`, or `query` |
 | --server | -s | market.hiclaw.io:80 when no host/port is provided | Nacos server address (deprecated, use --host and --port) |
 | --username | -u | nacos | Nacos username |
 | --password | -p | nacos | Nacos password |
@@ -559,6 +560,7 @@ scheme: http          # http or https (default: http)
 authType: nacos
 username: ENC[v1:aes-256-gcm:...]
 password: ENC[v1:aes-256-gcm:...]
+tokenTransport: bearer # bearer | authorization | header | query
 namespace: ""
 ```
 
@@ -585,6 +587,7 @@ nacos-cli profile get auth-type
 nacos-cli profile set dev host=127.0.0.1 port=8848 auth-type=none
 nacos-cli profile set dev host=127.0.0.1 port=8848 auth-type=token token=<token>
 nacos-cli profile set dev auth-type=nacos username=nacos password=nacos
+nacos-cli profile set dev token-transport=query
 nacos-cli profile set dev server=127.0.0.1:8848 namespace=public
 
 # Delete a profile
@@ -615,7 +618,14 @@ export NACOS_HOST=127.0.0.1
 export NACOS_PORT=8848
 export NACOS_NAMESPACE=xxx
 export NACOS_SCHEME=https    # http or https (default: http)
+export NACOS_TOKEN_TRANSPORT=query # bearer | authorization | header | query
 ```
+
+`bearer` sends `Authorization: Bearer <token>` and remains the default.
+`authorization` sends the raw token as `Authorization: <token>`, `header`
+sends `accessToken: <token>`, and `query` sends `?accessToken=<token>`.
+When a Nacos v3 configuration route returns 404 or 410, configuration list,
+get, and publish operations automatically fall back to the compatible v1 API.
 
 For example:
 - `nacos-cli --config ./local.conf --host 10.0.0.1` - Uses `10.0.0.1` from command line, other values from config file

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -18,17 +18,18 @@ var (
 	profileDeleteForce    bool
 	profileSetIncomplete  bool
 	profileKnownFieldKeys = map[string]bool{
-		"host":          true,
-		"port":          true,
-		"server":        true,
-		"authtype":      true,
-		"username":      true,
-		"password":      true,
-		"accesskey":     true,
-		"secretkey":     true,
-		"securitytoken": true,
-		"token":         true,
-		"namespace":     true,
+		"host":           true,
+		"port":           true,
+		"server":         true,
+		"authtype":       true,
+		"username":       true,
+		"password":       true,
+		"accesskey":      true,
+		"secretkey":      true,
+		"securitytoken":  true,
+		"token":          true,
+		"tokentransport": true,
+		"namespace":      true,
 	}
 )
 
@@ -138,6 +139,7 @@ Examples:
 				stsAuthTokenVal,
 				cfg.GetScheme(),
 				client.WithToken(cfg.Token),
+				client.WithTokenTransport(cfg.TokenTransport),
 			)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
@@ -196,6 +198,7 @@ Examples:
 		fmt.Printf("%-15s %s\n", "host:", cfg.Host)
 		fmt.Printf("%-15s %d\n", "port:", cfg.Port)
 		fmt.Printf("%-15s %s\n", "auth-type:", cfg.AuthType)
+		fmt.Printf("%-15s %s\n", "token-transport:", defaultTokenTransport(cfg.TokenTransport))
 		switch cfg.AuthType {
 		case "token":
 			fmt.Printf("%-15s %s\n", "token:", maskSensitiveValue(cfg.Token))
@@ -566,6 +569,7 @@ func printProfileValues(cfg *config.Config) {
 		"secret-key",
 		"security-token",
 		"token",
+		"token-transport",
 		"namespace",
 	} {
 		value, sensitive, err := cfg.GetValue(key)
@@ -577,6 +581,13 @@ func printProfileValues(cfg *config.Config) {
 		}
 		fmt.Printf("%s=%s\n", key, value)
 	}
+}
+
+func defaultTokenTransport(value string) string {
+	if value == "" {
+		return "bearer"
+	}
+	return value
 }
 
 func init() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,23 +14,24 @@ import (
 )
 
 var (
-	serverAddr    string
-	host          string
-	port          int
-	scheme        string
-	namespace     string
-	authType      string
-	username      string
-	password      string
-	accessKey     string
-	secretKey     string
-	securityToken string
-	token         string
-	stsURL        string
-	stsAuthToken  string
-	configFile    string
-	profileName   string // Profile name for config file (default, dev, prod, etc.)
-	verbose       bool   // Enable verbose/debug output
+	serverAddr     string
+	host           string
+	port           int
+	scheme         string
+	namespace      string
+	authType       string
+	username       string
+	password       string
+	accessKey      string
+	secretKey      string
+	securityToken  string
+	token          string
+	tokenTransport string
+	stsURL         string
+	stsAuthToken   string
+	configFile     string
+	profileName    string // Profile name for config file (default, dev, prod, etc.)
+	verbose        bool   // Enable verbose/debug output
 )
 
 var rootCmd = &cobra.Command{
@@ -59,7 +60,7 @@ Examples:
 		var err error
 
 		// Check if any connection parameters are provided via command line
-		hasCommandLineConfig := host != "" || port > 0 || serverAddr != "" || username != "" || password != "" || accessKey != "" || secretKey != "" || securityToken != "" || isCommandLineStsAuthType(authType) || scheme != ""
+		hasCommandLineConfig := host != "" || port > 0 || serverAddr != "" || username != "" || password != "" || accessKey != "" || secretKey != "" || securityToken != "" || tokenTransport != "" || isCommandLineStsAuthType(authType) || scheme != ""
 		envHost := strings.TrimSpace(os.Getenv("NACOS_HOST"))
 		envNamespace := strings.TrimSpace(os.Getenv("NACOS_NAMESPACE"))
 		envPortRaw := strings.TrimSpace(os.Getenv("NACOS_PORT"))
@@ -212,6 +213,18 @@ Examples:
 		if token == "" && fileConfig != nil {
 			token = fileConfig.Token
 		}
+		if tokenTransport == "" && fileConfig != nil {
+			tokenTransport = fileConfig.TokenTransport
+		}
+		if tokenTransport == "" {
+			tokenTransport = os.Getenv("NACOS_TOKEN_TRANSPORT")
+		}
+		normalizedTokenTransport, transportErr := client.NormalizeTokenTransport(tokenTransport)
+		if transportErr != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", transportErr)
+			os.Exit(1)
+		}
+		tokenTransport = normalizedTokenTransport
 
 		// Set default server address only when neither --host nor --port is provided.
 		if serverAddr == "" {
@@ -247,6 +260,7 @@ Examples:
 			fmt.Fprintf(os.Stderr, "[debug] scheme=%s\n", scheme)
 			fmt.Fprintf(os.Stderr, "[debug] serverAddr=%s\n", serverAddr)
 			fmt.Fprintf(os.Stderr, "[debug] namespace=%s\n", namespace)
+			fmt.Fprintf(os.Stderr, "[debug] tokenTransport=%s\n", tokenTransport)
 			if stsURL != "" {
 				fmt.Fprintf(os.Stderr, "[debug] stsURL=%s\n", stsURL)
 			}
@@ -366,6 +380,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&secretKey, "secret-key", "", "SecretKey (aliyun/STS auth)")
 	rootCmd.PersistentFlags().StringVar(&securityToken, "security-token", "", "STS SecurityToken (STS auth)")
 	rootCmd.PersistentFlags().StringVar(&token, "token", "", "Bearer token")
+	rootCmd.PersistentFlags().StringVar(&tokenTransport, "token-transport", "", "Access token transport: bearer, authorization, header, or query (default: bearer)")
 	rootCmd.PersistentFlags().BoolVar(&verbose, "verbose", false, "Enable verbose/debug output")
 
 	// Mark legacy server flag as deprecated but still functional
@@ -396,6 +411,7 @@ func mustNewNacosClient() *client.NacosClient {
 		serverAddr, namespace, authType, username, password,
 		accessKey, secretKey, securityToken, stsURL, stsAuthToken, scheme,
 		client.WithToken(token),
+		client.WithTokenTransport(tokenTransport),
 		func(c *client.NacosClient) {
 			c.Verbose = verbose
 		},

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -486,6 +486,7 @@ func resetRootConfigForTest(t *testing.T) {
 	originalSecretKey := secretKey
 	originalSecurityToken := securityToken
 	originalToken := token
+	originalTokenTransport := tokenTransport
 	originalStsURL := stsURL
 	originalStsAuthToken := stsAuthToken
 	originalConfigFile := configFile
@@ -504,6 +505,7 @@ func resetRootConfigForTest(t *testing.T) {
 	secretKey = ""
 	securityToken = ""
 	token = ""
+	tokenTransport = ""
 	stsURL = ""
 	stsAuthToken = ""
 	configFile = ""
@@ -523,6 +525,7 @@ func resetRootConfigForTest(t *testing.T) {
 		secretKey = originalSecretKey
 		securityToken = originalSecurityToken
 		token = originalToken
+		tokenTransport = originalTokenTransport
 		stsURL = originalStsURL
 		stsAuthToken = originalStsAuthToken
 		configFile = originalConfigFile

--- a/internal/client/nacos_client.go
+++ b/internal/client/nacos_client.go
@@ -26,6 +26,13 @@ const (
 	AuthTypeStsAgentTeams = "sts-agentteams" // STS temporary credential via AgentTeams controller
 )
 
+const (
+	TokenTransportBearer        = "bearer"
+	TokenTransportAuthorization = "authorization"
+	TokenTransportHeader        = "header"
+	TokenTransportQuery         = "query"
+)
+
 const DefaultHTTPTimeout = 30 * time.Second
 
 // defaultStsCredTTL is used when the STS endpoint omits both expires_in_sec
@@ -56,6 +63,7 @@ type NacosClient struct {
 	StsURL           string // STS credential endpoint URL
 	StsAuthToken     string // Bearer token for controller authentication
 	AccessToken      string
+	TokenTransport   string // bearer (default), authorization (raw), header (accessToken), or query
 	TokenExpireAt    time.Time
 	stsCredExpireAt  time.Time // expiration time of STS credentials
 	authLoginVersion string    // "v3" or "v1", determined by first successful login
@@ -76,6 +84,32 @@ func WithToken(token string) func(*NacosClient) {
 		}
 		c.AuthType = AuthTypeToken
 		c.AccessToken = token
+	}
+}
+
+// WithTokenTransport configures how Nacos access tokens are sent after login.
+// The default is the standard Authorization: Bearer header. Compatibility
+// servers may instead require a raw Authorization token, accessToken header,
+// or accessToken query parameter.
+func WithTokenTransport(transport string) func(*NacosClient) {
+	return func(c *NacosClient) {
+		if transport != "" {
+			c.TokenTransport = strings.ToLower(strings.TrimSpace(transport))
+		}
+	}
+}
+
+// NormalizeTokenTransport validates and normalizes the access-token transport.
+func NormalizeTokenTransport(transport string) (string, error) {
+	transport = strings.ToLower(strings.TrimSpace(transport))
+	if transport == "" {
+		return TokenTransportBearer, nil
+	}
+	switch transport {
+	case TokenTransportBearer, TokenTransportAuthorization, TokenTransportHeader, TokenTransportQuery:
+		return transport, nil
+	default:
+		return "", fmt.Errorf("invalid token transport %q (must be bearer, authorization, header, or query)", transport)
 	}
 }
 
@@ -178,26 +212,34 @@ func NewNacosClient(serverAddr, namespace, authType, username, password, accessK
 	}
 
 	c := &NacosClient{
-		ServerAddr:    serverAddr,
-		Scheme:        scheme,
-		Namespace:     namespace,
-		AuthType:      authType,
-		Username:      username,
-		Password:      password,
-		AccessKey:     accessKey,
-		SecretKey:     secretKey,
-		SecurityToken: securityToken,
-		StsURL:        stsURL,
-		StsAuthToken:  stsAuthToken,
-		httpClient:    resty.New().SetTimeout(DefaultHTTPTimeout),
-		rawHTTPClient: &http.Client{Timeout: DefaultHTTPTimeout},
+		ServerAddr:     serverAddr,
+		Scheme:         scheme,
+		Namespace:      namespace,
+		AuthType:       authType,
+		Username:       username,
+		Password:       password,
+		AccessKey:      accessKey,
+		SecretKey:      secretKey,
+		SecurityToken:  securityToken,
+		StsURL:         stsURL,
+		StsAuthToken:   stsAuthToken,
+		TokenTransport: TokenTransportBearer,
+		httpClient:     resty.New().SetTimeout(DefaultHTTPTimeout),
+		rawHTTPClient:  &http.Client{Timeout: DefaultHTTPTimeout},
 	}
 
 	for _, opt := range opts {
 		opt(c)
 	}
+	normalizedTransport, err := NormalizeTokenTransport(c.TokenTransport)
+	if err != nil {
+		return nil, err
+	}
+	c.TokenTransport = normalizedTransport
 	if c.AuthType == AuthTypeToken {
-		c.httpClient.SetHeader("Authorization", "Bearer "+c.AccessToken)
+		if c.TokenTransport == TokenTransportBearer {
+			c.httpClient.SetHeader("Authorization", "Bearer "+c.AccessToken)
+		}
 	}
 
 	switch c.AuthType {
@@ -213,6 +255,40 @@ func NewNacosClient(serverAddr, namespace, authType, username, password, accessK
 		}
 	}
 	return c, nil
+}
+
+func (c *NacosClient) applyAccessTokenResty(req *resty.Request) {
+	if c.AccessToken == "" {
+		return
+	}
+	switch c.TokenTransport {
+	case TokenTransportAuthorization:
+		req.SetHeader("Authorization", c.AccessToken)
+	case TokenTransportHeader:
+		req.SetHeader("accessToken", c.AccessToken)
+	case TokenTransportQuery:
+		req.SetQueryParam("accessToken", c.AccessToken)
+	default:
+		req.SetHeader("Authorization", "Bearer "+c.AccessToken)
+	}
+}
+
+func (c *NacosClient) applyAccessTokenHTTP(req *http.Request) {
+	if c.AccessToken == "" {
+		return
+	}
+	switch c.TokenTransport {
+	case TokenTransportAuthorization:
+		req.Header.Set("Authorization", c.AccessToken)
+	case TokenTransportHeader:
+		req.Header.Set("accessToken", c.AccessToken)
+	case TokenTransportQuery:
+		query := req.URL.Query()
+		query.Set("accessToken", c.AccessToken)
+		req.URL.RawQuery = query.Encode()
+	default:
+		req.Header.Set("Authorization", "Bearer "+c.AccessToken)
+	}
 }
 
 // HTTPClient returns the shared standard HTTP client used by APIs that need
@@ -488,10 +564,7 @@ func (c *NacosClient) NewAuthedRequest(method, url string, body io.Reader) (*htt
 	if err != nil {
 		return nil, err
 	}
-	// Bearer token (nacos auth)
-	if c.AccessToken != "" {
-		req.Header.Set("Authorization", "Bearer "+c.AccessToken)
-	}
+	c.applyAccessTokenHTTP(req)
 	// SPAS headers (aliyun/STS auth): tenant=namespaceId, group=DEFAULT_GROUP
 	if (c.AuthType == AuthTypeAliyun || IsStsAuthType(c.AuthType)) && c.AccessKey != "" && c.SecretKey != "" {
 		ts := strconv.FormatInt(time.Now().UnixMilli(), 10)
@@ -568,8 +641,8 @@ func (c *NacosClient) ListConfigs(dataID, groupName, namespaceID string, pageNo,
 	v3URL := fmt.Sprintf("%s/nacos/v3/admin/cs/config/list", c.BaseURL())
 	resp, err := c.doWithStsRetry(func() (*resty.Response, error) {
 		req := c.httpClient.R().SetQueryString(params.Encode())
-		if c.AuthType == AuthTypeNacos && c.AccessToken != "" {
-			req.SetHeader("Authorization", fmt.Sprintf("Bearer %s", c.AccessToken))
+		if c.AuthType == AuthTypeNacos {
+			c.applyAccessTokenResty(req)
 		}
 		c.setSpasHeaders(req, ns, groupName)
 		return req.Get(v3URL)
@@ -580,6 +653,9 @@ func (c *NacosClient) ListConfigs(dataID, groupName, namespaceID string, pageNo,
 	}
 
 	if resp.StatusCode() != 200 {
+		if resp.StatusCode() == http.StatusNotFound || resp.StatusCode() == http.StatusGone {
+			return c.listConfigsV1(dataID, groupName, ns, pageNo, pageSize)
+		}
 		return nil, ParseHTTPError(resp.StatusCode(), resp.Body(), "list configs")
 	}
 
@@ -665,8 +741,8 @@ func (c *NacosClient) GetConfig(dataID, group string) (string, error) {
 	apiURL := fmt.Sprintf("%s/nacos/v3/client/cs/config", c.BaseURL())
 	resp, err := c.doWithStsRetry(func() (*resty.Response, error) {
 		req := c.httpClient.R().SetQueryString(params.Encode())
-		if c.AuthType == AuthTypeNacos && c.AccessToken != "" {
-			req.SetHeader("Authorization", fmt.Sprintf("Bearer %s", c.AccessToken))
+		if c.AuthType == AuthTypeNacos {
+			c.applyAccessTokenResty(req)
 		}
 		c.setSpasHeaders(req, c.Namespace, group)
 		return req.Get(apiURL)
@@ -677,6 +753,9 @@ func (c *NacosClient) GetConfig(dataID, group string) (string, error) {
 	}
 
 	if resp.StatusCode() != 200 {
+		if resp.StatusCode() == http.StatusNotFound || resp.StatusCode() == http.StatusGone {
+			return c.getConfigV1(dataID, group)
+		}
 		return "", ParseHTTPError(resp.StatusCode(), resp.Body(), "get config")
 	}
 
@@ -704,6 +783,32 @@ func (c *NacosClient) GetConfig(dataID, group string) (string, error) {
 	return config.Content, nil
 }
 
+func (c *NacosClient) getConfigV1(dataID, group string) (string, error) {
+	params := url.Values{}
+	params.Set("dataId", dataID)
+	params.Set("group", group)
+	if c.Namespace != "" && c.Namespace != "public" {
+		params.Set("tenant", c.Namespace)
+	}
+	if c.AuthType == AuthTypeNacos && c.AccessToken != "" {
+		params.Set("accessToken", c.AccessToken)
+	}
+
+	apiURL := fmt.Sprintf("%s/nacos/v1/cs/configs", c.BaseURL())
+	resp, err := c.doWithStsRetry(func() (*resty.Response, error) {
+		req := c.httpClient.R().SetQueryString(params.Encode())
+		c.setSpasHeaders(req, c.Namespace, group)
+		return req.Get(apiURL)
+	})
+	if err != nil {
+		return "", fmt.Errorf("get config (v1) failed: %w", err)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return "", ParseHTTPError(resp.StatusCode(), resp.Body(), "get config (v1)")
+	}
+	return string(resp.Body()), nil
+}
+
 // PublishConfig publishes a configuration
 func (c *NacosClient) PublishConfig(dataID, group, content string) error {
 	if err := c.EnsureTokenValid(); err != nil {
@@ -722,8 +827,8 @@ func (c *NacosClient) PublishConfig(dataID, group, content string) error {
 	apiURL := fmt.Sprintf("%s/nacos/v3/admin/cs/config", c.BaseURL())
 	resp, err := c.doWithStsRetry(func() (*resty.Response, error) {
 		req := c.httpClient.R().SetFormData(params)
-		if c.AuthType == AuthTypeNacos && c.AccessToken != "" {
-			req.SetHeader("Authorization", fmt.Sprintf("Bearer %s", c.AccessToken))
+		if c.AuthType == AuthTypeNacos {
+			c.applyAccessTokenResty(req)
 		}
 		c.setSpasHeaders(req, c.Namespace, group)
 		return req.Post(apiURL)
@@ -734,6 +839,9 @@ func (c *NacosClient) PublishConfig(dataID, group, content string) error {
 	}
 
 	if resp.StatusCode() != 200 {
+		if resp.StatusCode() == http.StatusNotFound || resp.StatusCode() == http.StatusGone {
+			return c.publishConfigV1(dataID, group, content)
+		}
 		return ParseHTTPError(resp.StatusCode(), resp.Body(), "publish config")
 	}
 
@@ -755,5 +863,36 @@ func (c *NacosClient) PublishConfig(dataID, group, content string) error {
 		return fmt.Errorf("publish config failed: server returned false")
 	}
 
+	return nil
+}
+
+func (c *NacosClient) publishConfigV1(dataID, group, content string) error {
+	params := map[string]string{
+		"dataId":  dataID,
+		"group":   group,
+		"content": content,
+	}
+	if c.Namespace != "" && c.Namespace != "public" {
+		params["tenant"] = c.Namespace
+	}
+	if c.AuthType == AuthTypeNacos && c.AccessToken != "" {
+		params["accessToken"] = c.AccessToken
+	}
+
+	apiURL := fmt.Sprintf("%s/nacos/v1/cs/configs", c.BaseURL())
+	resp, err := c.doWithStsRetry(func() (*resty.Response, error) {
+		req := c.httpClient.R().SetFormData(params)
+		c.setSpasHeaders(req, c.Namespace, group)
+		return req.Post(apiURL)
+	})
+	if err != nil {
+		return fmt.Errorf("publish config (v1) failed: %w", err)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return ParseHTTPError(resp.StatusCode(), resp.Body(), "publish config (v1)")
+	}
+	if strings.TrimSpace(string(resp.Body())) != "true" {
+		return fmt.Errorf("publish config (v1) failed: server returned %s", string(resp.Body()))
+	}
 	return nil
 }

--- a/internal/client/nacos_client_test.go
+++ b/internal/client/nacos_client_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 )
 
@@ -207,5 +208,137 @@ func TestNewNacosClientWithTokenSetsAuthorizationHeader(t *testing.T) {
 	}
 	if got := c.httpClient.Header.Get("Authorization"); got != "Bearer test-token" {
 		t.Fatalf("resty Authorization header = %q, want %q", got, "Bearer test-token")
+	}
+}
+
+func TestNacosTokenTransportOnV3ConfigRequest(t *testing.T) {
+	tests := []struct {
+		name              string
+		transport         string
+		wantAuthorization string
+		wantAccessHeader  string
+		wantAccessQuery   string
+	}{
+		{name: "default bearer", wantAuthorization: "Bearer test-token"},
+		{name: "raw authorization", transport: TokenTransportAuthorization, wantAuthorization: "test-token"},
+		{name: "accessToken header", transport: TokenTransportHeader, wantAccessHeader: "test-token"},
+		{name: "accessToken query", transport: TokenTransportQuery, wantAccessQuery: "test-token"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/nacos/v3/auth/user/login":
+					_, _ = w.Write([]byte(`{"accessToken":"test-token","tokenTtl":18000}`))
+				case "/nacos/v3/client/cs/config":
+					if got := r.Header.Get("Authorization"); got != tt.wantAuthorization {
+						t.Errorf("Authorization header = %q, want %q", got, tt.wantAuthorization)
+					}
+					if got := r.Header.Get("accessToken"); got != tt.wantAccessHeader {
+						t.Errorf("accessToken header = %q, want %q", got, tt.wantAccessHeader)
+					}
+					if got := r.URL.Query().Get("accessToken"); got != tt.wantAccessQuery {
+						t.Errorf("accessToken query = %q, want %q", got, tt.wantAccessQuery)
+					}
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(`{"code":0,"message":"","data":{"content":"ok"}}`))
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer server.Close()
+
+			serverURL, err := url.Parse(server.URL)
+			if err != nil {
+				t.Fatal(err)
+			}
+			client, err := NewNacosClient(
+				serverURL.Host, "public", AuthTypeNacos,
+				"user", "password", "", "", "", "", "", serverURL.Scheme,
+				WithTokenTransport(tt.transport),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			content, err := client.GetConfig("test", "DEFAULT_GROUP")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if content != "ok" {
+				t.Fatalf("content = %q, want ok", content)
+			}
+		})
+	}
+}
+
+func TestNormalizeTokenTransportRejectsInvalidValue(t *testing.T) {
+	if _, err := NormalizeTokenTransport("cookie"); err == nil {
+		t.Fatal("NormalizeTokenTransport accepted invalid value")
+	}
+}
+
+func TestConfigAPIsFallBackToV1OnMissingV3Routes(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/nacos/v3/auth/user/login":
+			_, _ = w.Write([]byte(`{"accessToken":"test-token","tokenTtl":18000}`))
+		case "/nacos/v3/admin/cs/config/list", "/nacos/v3/client/cs/config", "/nacos/v3/admin/cs/config":
+			http.NotFound(w, r)
+		case "/nacos/v1/cs/configs":
+			if r.Method == http.MethodPost {
+				if err := r.ParseForm(); err != nil {
+					t.Fatal(err)
+				}
+				if got := r.Form.Get("accessToken"); got != "test-token" {
+					t.Errorf("publish accessToken = %q, want test-token", got)
+				}
+				_, _ = w.Write([]byte("true"))
+				return
+			}
+			if got := r.URL.Query().Get("accessToken"); got != "test-token" {
+				t.Errorf("query accessToken = %q, want test-token", got)
+			}
+			if r.URL.Query().Get("pageNo") != "" {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"totalCount":1,"pageNumber":1,"pagesAvailable":1,"pageItems":[{"dataId":"test","group":"DEFAULT_GROUP"}]}`))
+				return
+			}
+			_, _ = w.Write([]byte("content-from-v1"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, err := NewNacosClient(
+		serverURL.Host, "namespace", AuthTypeNacos,
+		"user", "password", "", "", "", "", "", serverURL.Scheme,
+		WithTokenTransport(TokenTransportQuery),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	configs, err := c.ListConfigs("*", "*", "namespace", 1, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if configs.TotalCount != 1 {
+		t.Fatalf("TotalCount = %d, want 1", configs.TotalCount)
+	}
+	content, err := c.GetConfig("test", "DEFAULT_GROUP")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if content != "content-from-v1" {
+		t.Fatalf("content = %q, want content-from-v1", content)
+	}
+	if err := c.PublishConfig("test", "DEFAULT_GROUP", "updated"); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,17 +22,18 @@ const (
 
 // Config represents the Nacos CLI configuration
 type Config struct {
-	Host          string `yaml:"host"`
-	Port          int    `yaml:"port"`
-	Scheme        string `yaml:"scheme"`   // http | https (default: http)
-	AuthType      string `yaml:"authType"` // token | nacos | aliyun | sts-hiclaw | sts-agentteams
-	Username      string `yaml:"username"`
-	Password      string `yaml:"password"`
-	AccessKey     string `yaml:"accessKey"`     // Aliyun AK (AuthType=aliyun)
-	SecretKey     string `yaml:"secretKey"`     // Aliyun SK (AuthType=aliyun)
-	SecurityToken string `yaml:"securityToken"` // STS SecurityToken (legacy)
-	Token         string `yaml:"token"`         // Bearer token (AuthType=token)
-	Namespace     string `yaml:"namespace"`
+	Host           string `yaml:"host"`
+	Port           int    `yaml:"port"`
+	Scheme         string `yaml:"scheme"`   // http | https (default: http)
+	AuthType       string `yaml:"authType"` // token | nacos | aliyun | sts-hiclaw | sts-agentteams
+	Username       string `yaml:"username"`
+	Password       string `yaml:"password"`
+	AccessKey      string `yaml:"accessKey"`      // Aliyun AK (AuthType=aliyun)
+	SecretKey      string `yaml:"secretKey"`      // Aliyun SK (AuthType=aliyun)
+	SecurityToken  string `yaml:"securityToken"`  // STS SecurityToken (legacy)
+	Token          string `yaml:"token"`          // Bearer token (AuthType=token)
+	TokenTransport string `yaml:"tokenTransport"` // bearer | authorization | header | query
+	Namespace      string `yaml:"namespace"`
 }
 
 // Settings stores CLI-wide profile state.
@@ -434,6 +435,12 @@ func (c *Config) SetValue(key, value string) error {
 		c.SecurityToken = value
 	case "token":
 		c.Token = value
+	case "tokentransport":
+		transport, err := normalizeTokenTransport(value)
+		if err != nil {
+			return err
+		}
+		c.TokenTransport = transport
 	case "namespace":
 		c.Namespace = value
 	default:
@@ -468,10 +475,25 @@ func (c *Config) GetValue(key string) (string, bool, error) {
 		return c.SecurityToken, true, nil
 	case "token":
 		return c.Token, true, nil
+	case "tokentransport":
+		return c.TokenTransport, false, nil
 	case "namespace":
 		return c.Namespace, false, nil
 	default:
 		return "", false, fmt.Errorf("unknown profile key %q", key)
+	}
+}
+
+func normalizeTokenTransport(value string) (string, error) {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "" {
+		return "", nil
+	}
+	switch value {
+	case "bearer", "authorization", "header", "query":
+		return value, nil
+	default:
+		return "", fmt.Errorf("invalid token transport %q (must be bearer, authorization, header, or query)", value)
 	}
 }
 
@@ -958,6 +980,24 @@ func (c *Config) PromptForUpdate() error {
 		}
 		if c.Password == "" {
 			return fmt.Errorf("password is required")
+		}
+
+		currentTransport := c.TokenTransport
+		if currentTransport == "" {
+			currentTransport = "bearer"
+		}
+		fmt.Printf("Enter token transport [bearer|authorization|header|query] [%s]: ", currentTransport)
+		input, err = reader.ReadString('\n')
+		if err != nil {
+			return fmt.Errorf("failed to read token transport: %w", err)
+		}
+		input = strings.TrimSpace(input)
+		if input != "" {
+			transport, transportErr := normalizeTokenTransport(input)
+			if transportErr != nil {
+				return transportErr
+			}
+			c.TokenTransport = transport
 		}
 	}
 	// authType == "none": skip credential prompts

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -243,6 +243,26 @@ func TestConfigWithSchemeField(t *testing.T) {
 	}
 }
 
+func TestConfigTokenTransportField(t *testing.T) {
+	cfg := &Config{}
+	if err := cfg.SetValue("token-transport", "QUERY"); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.TokenTransport != "query" {
+		t.Fatalf("TokenTransport = %q, want query", cfg.TokenTransport)
+	}
+	value, sensitive, err := cfg.GetValue("token-transport")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if value != "query" || sensitive {
+		t.Fatalf("GetValue() = (%q, %v), want (query, false)", value, sensitive)
+	}
+	if err := cfg.SetValue("token-transport", "cookie"); err == nil {
+		t.Fatal("SetValue accepted invalid token transport")
+	}
+}
+
 func TestCurrentProfileSettings(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 


### PR DESCRIPTION
## Summary

- add configurable Nacos access-token transport: `bearer`, raw `authorization`, `header`, or `query`
- keep `bearer` as the default for backward compatibility
- fall back from missing Nacos v3 configuration routes (404/410) to the compatible v1 list/get/publish APIs
- expose the setting through `--token-transport`, profile YAML, profile commands, and `NACOS_TOKEN_TRANSPORT`

## Motivation

R-Nacos v0.8.5 accepts its login token as either a raw `Authorization` value or an `accessToken` query parameter. It does not strip the `Bearer ` prefix. It also exposes the compatible v1 configuration APIs while the v3 configuration routes used by nacos-cli can return 404.

This keeps the existing behavior for standard Nacos while allowing compatibility servers to select the token transport they implement.

## Validation

- focused unit tests for all four token transports
- unit tests for v3-to-v1 list/get/publish fallback
- `go build ./...`
- Windows amd64 and Linux amd64 builds
- live read-only validation against R-Nacos v0.8.5 over HTTPS:
  - `config-list`: success
  - `config-get`: success
  - no configuration content logged during validation

The full Windows test suite has unrelated failures caused by local home-directory state and unavailable symlink privileges; the affected focused tests pass.